### PR TITLE
deploy: add namespace to Role and RoleBindings

### DIFF
--- a/deploy/02-rbac.yaml
+++ b/deploy/02-rbac.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-samples-operator
+  namespace: openshift-cluster-samples-operator
 rules:
 - apiGroups:
   - samplesoperator.config.openshift.io
@@ -37,6 +38,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: default-account-cluster-samples-operator
+  namespace: openshift-cluster-samples-operator
 subjects:
 - kind: ServiceAccount
   name: default


### PR DESCRIPTION
Anybody using these manfiests doesn't have information or context
to find which namespace these Namespaced Object need to be installed.
For example, ClusterVersionOperator wouldn't know which namespace to choose.