### PR TITLE
get rid of cached samplesresource; add cfg base duplicate event check

### DIFF
--- a/cmd/cluster-samples-operator/main.go
+++ b/cmd/cluster-samples-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime"
 
+	"github.com/openshift/cluster-samples-operator/pkg/apis/samplesoperator/v1alpha1"
 	stub "github.com/openshift/cluster-samples-operator/pkg/stub"
 	sdk "github.com/operator-framework/operator-sdk/pkg/sdk"
 	k8sutil "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
@@ -24,7 +25,7 @@ func main() {
 
 	sdk.ExposeMetricsPort()
 
-	resource := "samplesoperator.config.openshift.io/v1alpha1"
+	resource := v1alpha1.GroupName + "/" + v1alpha1.Version
 	kind := "SamplesResource"
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/pkg/apis/samplesoperator/v1alpha1/register.go
+++ b/pkg/apis/samplesoperator/v1alpha1/register.go
@@ -9,15 +9,15 @@ import (
 )
 
 const (
-	version   = "v1alpha1"
-	groupName = "samplesoperator.config.openshift.io"
+	Version   = "v1alpha1"
+	GroupName = "samplesoperator.config.openshift.io"
 )
 
 var (
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	AddToScheme   = SchemeBuilder.AddToScheme
 	// SchemeGroupVersion is the group version used to register these objects.
-	SchemeGroupVersion = schema.GroupVersion{Group: groupName, Version: version}
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: Version}
 )
 
 func init() {


### PR DESCRIPTION
a couple of the follow up items from the initial clusteroperator status PR @bparees and I sorted through last week

got motivated to do this now cause the reduction in imagestream/template update churn in my libvirt env really sped up the demo

@openshift/sig-developer-experience 