### PR TITLE
add samples watches; fix sdk get/upd/create retry; other minor fixes

### DIFF
--- a/cmd/cluster-samples-operator/main.go
+++ b/cmd/cluster-samples-operator/main.go
@@ -10,6 +10,9 @@ import (
 	k8sutil "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
+	imagev1 "github.com/openshift/api/image/v1"
+	templatev1 "github.com/openshift/api/template/v1"
+
 	"github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
@@ -36,6 +39,11 @@ func main() {
 	sdk.Watch(resource, kind, "", resyncPeriod)
 	logrus.Infof("Watching secrets")
 	sdk.Watch("v1", "Secret", namespace, resyncPeriod)
+	sdk.Watch("v1", "Secret", "openshift", resyncPeriod)
+	k8sutil.AddToSDKScheme(imagev1.AddToScheme)
+	k8sutil.AddToSDKScheme(templatev1.AddToScheme)
+	sdk.Watch(imagev1.SchemeGroupVersion.String(), "ImageStream", "openshift", resyncPeriod)
+	sdk.Watch(templatev1.SchemeGroupVersion.String(), "Template", "openshift", resyncPeriod)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
 }

--- a/pkg/apis/samplesoperator/v1alpha1/types.go
+++ b/pkg/apis/samplesoperator/v1alpha1/types.go
@@ -48,10 +48,22 @@ const (
 	PPCArchitecture = "ppc64le"
 	// SamplesResourceFinalizer is the text added to the SamplesResource.Finalizer field
 	// to enable finalizer processing.
-	SamplesResourceFinalizer = "samplesoperator.config.openshift.io/finalizer"
-	// SamplesResourceLabel is the key for a label added to all the imagestreams and templates
-	// in the openshift namespace that the SamplesResource is managing.
-	SamplesResourceLabel = "samplesoperator.config.openshift.io/managed"
+	SamplesResourceFinalizer = GroupName + "/finalizer"
+	// SamplesManagedLabel is the key for a label added to all the imagestreams and templates
+	// in the openshift namespace that the SamplesResource is managing.  This label is adjusted
+	// when changes to the SkippedImagestreams and SkippedTemplates fields are made.
+	SamplesManagedLabel = GroupName + "/managed"
+	// SamplesVersionAnnotation is the key for an annotation set on the imagestreams, templates,
+	// and secret that this operator manages that signifies the version of the operator that
+	// last managed the particular resource.
+	SamplesVersionAnnotation = GroupName + "/version"
+)
+
+var (
+	//TODO eventually we will want this off of the commit or something that correlates to versions in the code repo
+	// CodeLevel is a precise code version level that the operator will use to determine whether it ias
+	// been upgraded, and by extension, whether the samples should be updated.
+	CodeLevel = "v0.0.1"
 )
 
 type SamplesResourceSpec struct {

--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -99,8 +99,7 @@ func (o *CVOOperatorStatusHandler) setOperatorStatus(name string, condtype osapi
 				return fmt.Errorf("failed to get cluster operator resource %s/%s: %s", state.ObjectMeta.Namespace, state.ObjectMeta.Name, err)
 			}
 
-			//TODO eventually we will want this off of the commit or something that correlates to versions in the code repo
-			state.Status.Version = "v0.0.1"
+			state.Status.Version = v1alpha1.CodeLevel
 
 			state.Status.Conditions = []osapi.ClusterOperatorStatusCondition{
 				{


### PR DESCRIPTION
@openshift/sig-developer-experience fyi

/assign @bparees 

includes comment detailing my failed attempts to use the current sdk version vendored in to watch imagestreams and templates ... not just using "v1" as the api version failed (though with a basic could not find the resource error) ... the `k8sutil.RuntimeObjectFromUnstructured` is what bombs trying to convert the json payload into a go struct/obj.