### PR TITLE
add image refs, env vars, so we can get jenkins images from payload

### DIFF
--- a/deploy/05-operator.yaml
+++ b/deploy/05-operator.yaml
@@ -36,4 +36,10 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
-              value: "cluster-samples-operator"
+              value: cluster-samples-operator
+            - name: IMAGE_JENKINS
+              value: quay.io/openshift/origin-jenkins:latest
+            - name: IMAGE_AGENT_NODEJS
+              value: quay.io/openshift/origin-jenkins-agent-nodejs:latest
+            - name: IMAGE_AGENT_MAVEN
+              value: quay.io/openshift/origin-jenkins-agent-maven:latest

--- a/deploy/image-references
+++ b/deploy/image-references
@@ -6,3 +6,15 @@ spec:
     from:
       kind: DockerImage
       name: docker.io/openshift/origin-cluster-samples-operator:latest
+  - name: jenkins
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-jenkins:latest
+  - name: jenkins-agent-nodejs
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-jenkins-agent-nodejs:latest
+  - name: jenkins-agent-maven
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-jenkins-agent-maven:latest

--- a/pkg/stub/interfaces.go
+++ b/pkg/stub/interfaces.go
@@ -141,6 +141,14 @@ func (g *DefaultImageStreamFromFileGetter) Get(fullFilePath string) (is *imagev1
 	if err != nil {
 		return nil, err
 	}
+	switch {
+	case imagestream.Name == "jenkins":
+		imagestream = tagInPayload("2", "IMAGE_JENKINS", imagestream)
+	case imagestream.Name == "jenkins-agent-maven":
+		imagestream = tagInPayload("v4.0", "IMAGE_AGENT_MAVEN", imagestream)
+	case imagestream.Name == "jenkins-agent-nodejs":
+		imagestream = tagInPayload("v4.0", "IMAGE_AGENT_NODEJS", imagestream)
+	}
 
 	return imagestream, nil
 }

--- a/pkg/stub/jenkins.go
+++ b/pkg/stub/jenkins.go
@@ -1,0 +1,23 @@
+package stub
+
+import (
+	"os"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/sirupsen/logrus"
+)
+
+func tagInPayload(tag, env string, stream *imagev1.ImageStream) *imagev1.ImageStream {
+	imageRef := os.Getenv(env)
+	if len(imageRef) == 0 {
+		logrus.Warningf("The environment variable %s was not set and we cannot update the %s:%s image references", env, stream.Name, tag)
+		return stream
+	}
+	for _, tagSpec := range stream.Spec.Tags {
+		if tagSpec.Name == tag {
+			tagSpec.From.Name = imageRef
+			break
+		}
+	}
+	return stream
+}


### PR DESCRIPTION
/assign @bparees 

ptal to review at least the yaml/ref stuff

in theory we could just merge this, but ideally I can wire in the processing of the new env's in the samples operator code with this PR as well

I'd like to start on those after https://github.com/openshift/cluster-samples-operator/pull/81