### PR TITLE
Move the cli image stream into samples operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN make build
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-samples-operator/cluster-samples-operator /usr/bin/
-COPY deploy/image-references deploy/00-crd.yaml deploy/01-namespace.yaml deploy/02-sa.yaml  deploy/03-rbac.yaml  deploy/04-openshift-rbac.yaml  deploy/05-operator.yaml /manifests/
+COPY deploy/image-references deploy/0* /manifests/
 COPY tmp/build/assets /opt/openshift/
 RUN useradd cluster-samples-operator
 USER cluster-samples-operator

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -5,7 +5,7 @@ RUN make build
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-samples-operator/cluster-samples-operator /usr/bin/
-COPY deploy/image-references deploy/00-crd.yaml deploy/01-namespace.yaml deploy/02-sa.yaml  deploy/03-rbac.yaml  deploy/04-openshift-rbac.yaml  deploy/05-operator.yaml /manifests/
+COPY deploy/image-references deploy/0* /manifests/
 COPY tmp/build/assets /opt/openshift/
 RUN useradd cluster-samples-operator
 USER cluster-samples-operator

--- a/deploy/06-openshift-imagestreams.yaml
+++ b/deploy/06-openshift-imagestreams.yaml
@@ -1,0 +1,38 @@
+# The image streams in this file will be the canonical reference points
+# for consumers within the cluster to loosely reference these images.
+#
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: cli
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-cli:v4.0
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: installer
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-installer:v4.0
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: tests
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-tests:v4.0

--- a/deploy/image-references
+++ b/deploy/image-references
@@ -2,10 +2,18 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
+  - name: cli
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-cli:v4.0
   - name: cluster-samples-operator
     from:
       kind: DockerImage
       name: docker.io/openshift/origin-cluster-samples-operator:latest
+  - name: installer
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-installer:v4.0
   - name: jenkins
     from:
       kind: DockerImage
@@ -18,3 +26,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-jenkins-agent-maven:latest
+  - name: tests
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-tests:v4.0


### PR DESCRIPTION
Add installer, which was the next dependency we need to include with
the cluster.

@bparees I realized that having where it is now (in the cli image) is a big
problem because everyone who descends from the cli image was getting added
multiple times during release creation, including jenkins agents. Once this moves
I can delete it out of origin.