### PR TITLE
BUG 1697644: operator: use openshift-config/pull-secret to fetch the pull secret

### DIFF
--- a/manifests/05-kube-system-rbac.yaml
+++ b/manifests/05-kube-system-rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: coreos-pull-secret-reader
-  namespace: kube-system
+  namespace: openshift-config
 rules:
 - apiGroups:
   - ""
@@ -18,8 +18,8 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-samples-operator-kube-system-secret-reader
-  namespace: kube-system
+  name: cluster-samples-operator-openshift-config-secret-reader
+  namespace: openshift-config
 subjects:
 - kind: ServiceAccount
   name: cluster-samples-operator

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -84,7 +84,7 @@ func NewController() (*Controller, error) {
 		cvowrapper:     operatorstatus.NewClusterOperatorHandler(operatorClient),
 		crWorkqueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "samplesconfig-changes"),
 		osSecWorkqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "openshift-secret-changes"),
-		opSecWorkqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kube-system-namespace-secret-changes"),
+		opSecWorkqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "openshift-config-namespace-secret-changes"),
 		isWorkqueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "imagestream-changes"),
 		tWorkqueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "template-changes"),
 		listers:        listers,
@@ -119,7 +119,7 @@ func NewController() (*Controller, error) {
 	}
 
 	c.kubeOSNSInformerFactory = kubeinformers.NewFilteredSharedInformerFactory(kubeClient, defaultResyncDuration, "openshift", nil)
-	c.kubeOPNSInformerFactory = kubeinformers.NewFilteredSharedInformerFactory(kubeClient, defaultResyncDuration, "kube-system", nil)
+	c.kubeOPNSInformerFactory = kubeinformers.NewFilteredSharedInformerFactory(kubeClient, defaultResyncDuration, "openshift-config", nil)
 	//TODO - eventually a k8s go-client deps bump will lead to the form below, similar to the image registry operator's kubeinformer initialization,
 	// and similar to what is available with the openshift go-client for imagestreams and templates
 	//kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncDuration, kubeinformers.WithNamespace("kube-system"))
@@ -133,7 +133,7 @@ func NewController() (*Controller, error) {
 
 	c.opSecInformer = c.kubeOPNSInformerFactory.Core().V1().Secrets().Informer()
 	c.opSecInformer.AddEventHandler(c.opSecretInformerEventHandler())
-	c.listers.OperatorNamespaceSecrets = c.kubeOPNSInformerFactory.Core().V1().Secrets().Lister().Secrets("kube-system")
+	c.listers.OperatorNamespaceSecrets = c.kubeOPNSInformerFactory.Core().V1().Secrets().Lister().Secrets("openshift-config")
 
 	c.isInformer = c.imageInformerFactory.Image().V1().ImageStreams().Informer()
 	c.isInformer.AddEventHandler(c.imagestreamInformerEventHandler())

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -416,7 +416,7 @@ func (h *Handler) Handle(event v1.Event) error {
 
 		// if we miss a delete event in the openshift namespace (since we cannot
 		// add a finalizer in our namespace secret), we our watch
-		// on the kube-system coreos pull secret should still repopulate;
+		// on the openshift-config pull secret should still repopulate;
 		// if that gets deleted, the whole cluster is hosed; plus, there is talk
 		// of moving data like that to a special config namespace that is somehow
 		// protected

--- a/pkg/stub/secrets.go
+++ b/pkg/stub/secrets.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	coreosPullSecretNamespace = "kube-system"
-	coreosPullSecretName      = "coreos-pull-secret"
+	coreosPullSecretNamespace = "openshift-config"
+	coreosPullSecretName      = "pull-secret"
 )
 
 func (h *Handler) copyDefaultClusterPullSecret(secret *corev1.Secret) error {
@@ -74,7 +74,7 @@ func (h *Handler) manageDockerCfgSecret(deleted bool, cfg *v1.Config, secret *co
 		}
 
 	case coreosPullSecretName:
-		// if kube-system deleted, we'll delete ours
+		// if openshift-config deleted, we'll delete ours
 		if deleted {
 			err := h.secretclientwrapper.Delete("openshift", v1.SamplesRegistryCredentials, &metav1.DeleteOptions{})
 			if err != nil && !kerrors.IsNotFound(err) {


### PR DESCRIPTION
The operator should be using the openshift-config/pull-secret as the kube-system/coreos-pull-secret has been marked deprecated.