### PR TITLE
Add the cli-artifacts and installer-artifacts images to the payload

### DIFF
--- a/manifests/06-operator.yaml
+++ b/manifests/06-operator.yaml
@@ -23,7 +23,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-samples-operator
-        image: docker.io/openshift/origin-cluster-samples-operator:latest
+        image: quay.io/openshift/origin-cluster-samples-operator:latest
         ports:
         - containerPort: 60000
           name: metrics

--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -11,7 +11,19 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-cli:v4.0
+      name: quay.io/openshift/origin-cli:v4.0
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: cli-artifacts
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-cli-artifacts:v4.0
 ---
 kind: ImageStream
 apiVersion: image.openshift.io/v1
@@ -23,7 +35,19 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-installer:v4.0
+      name: quay.io/openshift/origin-installer:v4.0
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: installer-artifacts
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-installer-artifacts:v4.0
 ---
 kind: ImageStream
 apiVersion: image.openshift.io/v1
@@ -35,7 +59,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-tests:v4.0
+      name: quay.io/openshift/origin-tests:v4.0
 ---
 kind: ImageStream
 apiVersion: image.openshift.io/v1
@@ -47,4 +71,4 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: docker.io/openshift/ose-must-gather:v4.0
+        name: quay.io/openshift/origin-must-gather:v4.0

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,15 +5,23 @@ spec:
   - name: cli
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-cli:v4.0
+      name: quay.io/openshift/origin-cli:v4.0
+  - name: cli-artifacts
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-cli-artifacts:v4.0
   - name: cluster-samples-operator
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-cluster-samples-operator:latest
+      name: quay.io/openshift/origin-cluster-samples-operator:latest
   - name: installer
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-installer:v4.0
+      name: quay.io/openshift/origin-installer:v4.0
+  - name: installer-artifacts
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-installer-artifacts:v4.0
   - name: jenkins
     from:
       kind: DockerImage
@@ -29,8 +37,8 @@ spec:
   - name: tests
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-tests:v4.0
+      name: quay.io/openshift/origin-tests:v4.0
   - name: must-gather
     from:
       kind: DockerImage
-      name: docker.io/openshift/ose-must-gather:v4.0
+      name: quay.io/openshift/origin-must-gather:v4.0


### PR DESCRIPTION
They will be used by `oc adm release extract --tools` to get windows
and mac binaries for oc and installer.

In addition, fix the input images to be consistent and use quay.