### PR TITLE
fix clusteroperator related-objects, set with updatestatus vs. create

### DIFF
--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -103,12 +103,6 @@ func (o *ClusterOperatorHandler) setOperatorStatus(condtype configv1.ClusterStat
 			state = &configv1.ClusterOperator{}
 			state.Name = ClusterOperatorName
 
-			state.Status.RelatedObjects = []configv1.ObjectReference{
-				{Group: v1.GroupName, Resource: "configs", Name: "cluster"},
-				{Resource: "namespaces", Name: "openshift-cluster-samples-operator"},
-				{Resource: "namespaces", Name: "openshift"},
-			}
-
 			state.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
 				{
 					Type:               configv1.OperatorAvailable,
@@ -168,6 +162,12 @@ func (o *ClusterOperatorHandler) setOperatorStatus(condtype configv1.ClusterStat
 
 		if !modified {
 			return nil
+		}
+
+		state.Status.RelatedObjects = []configv1.ObjectReference{
+			{Group: v1.GroupName, Resource: "configs", Name: "cluster"},
+			{Resource: "namespaces", Name: "openshift-cluster-samples-operator"},
+			{Resource: "namespaces", Name: "openshift"},
 		}
 
 		return o.ClusterOperatorWrapper.UpdateStatus(state)


### PR DESCRIPTION
@openshift/sig-developer-experience fyi

/assign @adambkaplan 

thanks @dmage for heads up

Now looks like:

```
gmontero ~ $ oc get clusteroperator openshift-samples -o yaml
apiVersion: config.openshift.io/v1
kind: ClusterOperator
metadata:
  creationTimestamp: "2019-05-06T19:16:47Z"
  generation: 1
  name: openshift-samples
  resourceVersion: "80560"
  selfLink: /apis/config.openshift.io/v1/clusteroperators/openshift-samples
  uid: 7e080c2f-7033-11e9-a8ac-0a985de94f40
spec: {}
status:
  conditions:
  - lastTransitionTime: "2019-05-06T19:17:34Z"
    message: Samples installation successful at 4.1.0-0.okd-2019-05-06-134910
    status: "True"
    type: Available
  - lastTransitionTime: "2019-05-06T19:17:34Z"
    message: Samples installation successful at 4.1.0-0.okd-2019-05-06-134910
    status: "False"
    type: Progressing
  - lastTransitionTime: "2019-05-06T19:16:57Z"
    status: "False"
    type: Degraded
  extension: null
  relatedObjects:
  - group: samples.operator.openshift.io
    name: cluster
    resource: configs
  - group: ""
    name: openshift-cluster-samples-operator
    resource: namespaces
  - group: ""
    name: openshift
    resource: namespaces
  versions:
  - name: operator
    version: 4.1.0-0.okd-2019-05-06-134910
gmontero ~ $ 
```