### PR TITLE
update Makefile to golang 1.11 for local dev (openshift/release confi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-samples-operator
 COPY . .
 RUN make build


### PR DESCRIPTION
…g sets it for api.ci builds)

note: origin-v4.1:base does not exist yet 