### PR TITLE
Bug 1717124: add clusterrole to allow cluster-reader access to the samples config obj

### DIFF
--- a/manifests/03-rbac.yaml
+++ b/manifests/03-rbac.yaml
@@ -50,6 +50,25 @@ rules:
 
 ---
 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  name: system:openshift:cluster-samples-operator:cluster-reader
+rules:
+- apiGroups:
+  - samples.operator.openshift.io
+  resources:
+  - configs
+  - configs/status
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
@openshift/openshift-team-developer-experience fyi ... I think image-registry-operator and openshift-controller-manager-operator could use this as well for the cfg objs ...thoughts?

/assign @adambkaplan 
/assign @enj 

@enj - if you have the cycles, PTAL as well, but conversely I can unassign you if you like