### PR TITLE
Bug 1739214:  set degraded reason/msg on cluster operator obj when degraded==true

### DIFF
--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -60,12 +60,12 @@ type ClusterOperatorWrapper interface {
 
 func (o *ClusterOperatorHandler) UpdateOperatorStatus(cfg *v1.Config) error {
 	var err error
-	failing, msgForProgressing, msgForFailing := cfg.ClusterOperatorStatusFailingCondition()
+	failing, failingReason, failingDetail := cfg.ClusterOperatorStatusFailingCondition()
 	err = o.setOperatorStatus(configv1.OperatorDegraded,
 		failing,
-		msgForFailing,
+		failingDetail,
 		"",
-		"")
+		failingReason)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (o *ClusterOperatorHandler) UpdateOperatorStatus(cfg *v1.Config) error {
 		return err
 	}
 
-	progressing, msgForProgressing, reasonForProgressing := cfg.ClusterOperatorStatusProgressingCondition(msgForProgressing, available)
+	progressing, msgForProgressing, reasonForProgressing := cfg.ClusterOperatorStatusProgressingCondition(failingReason, available)
 	err = o.setOperatorStatus(configv1.OperatorProgressing,
 		progressing,
 		msgForProgressing,

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -828,9 +828,12 @@ func TestImageStreamImportError(t *testing.T) {
 			importErr.LastTransitionTime = metav1.Now()
 		}
 		cfg.ConditionUpdate(importErr)
-		status, _, _ := cfg.ClusterOperatorStatusFailingCondition()
+		status, reason, detail := cfg.ClusterOperatorStatusFailingCondition()
 		if (status != configv1.ConditionTrue && turnBackThreeHours) || (status == configv1.ConditionTrue && !turnBackThreeHours) {
 			t.Fatalf("image import error from %#v not reflected in cluster status %#v", is, cfg)
+		}
+		if status == configv1.ConditionFalse && turnBackThreeHours && (len(reason) == 0 || len(detail) == 0) {
+			t.Fatalf("image import error from is %#v with cfg %#v had reason %s and detail %s", is, cfg, reason, detail)
 		}
 		turnBackThreeHours = !turnBackThreeHours
 	}


### PR DESCRIPTION
@openshift/openshift-team-developer-experience @bparees FYI / PTAL

see line 97 for the params defined for `setOperatorStatus`