### PR TITLE
Revert "Add baremetal-installer to image-references"

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -18,10 +18,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-installer:v4.0
-  - name: baremetal-installer
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-baremetal-installer:v4.2
   - name: installer-artifacts
     from:
       kind: DockerImage


### PR DESCRIPTION
This reverts commit f070c1458e47c32db783058711a25fca7f725cea, #170

It's failing for [ART-built nightlies][1]:

```
  error: unable to create a release: operator "cluster-samples-operator" contained an invalid image-references file: no input image tag named "baremetal-installer"
```

[1]: https://openshift-release.svc.ci.openshift.org/releasestream/4.2.0-0.nightly/release/4.2.0-0.nightly-2019-08-14-154809