### PR TITLE
Revert "Add baremetal-installer to image-references"

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -18,10 +18,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-installer:v4.0
-  - name: baremetal-installer
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-baremetal-installer:v4.2
   - name: installer-artifacts
     from:
       kind: DockerImage


### PR DESCRIPTION
This reverts commit f070c1458e47c32db783058711a25fca7f725cea, as it is
making nightlies fail.