### PR TITLE
add registry.svc.ci.openshift.org to the list of overridable registri…

### DIFF
--- a/pkg/stub/imagestreams.go
+++ b/pkg/stub/imagestreams.go
@@ -183,7 +183,7 @@ func (h *Handler) upsertImageStream(imagestreamInOperatorImage, imagestreamInClu
 		return nil
 	}
 
-	h.updateDockerPullSpec([]string{"docker.io", "registry.redhat.io", "registry.access.redhat.com", "quay.io"}, imagestreamInOperatorImage, opcfg)
+	h.updateDockerPullSpec([]string{"docker.io", "registry.redhat.io", "registry.access.redhat.com", "quay.io", "registry.svc.ci.openshift.org"}, imagestreamInOperatorImage, opcfg)
 
 	if imagestreamInOperatorImage.Labels == nil {
 		imagestreamInOperatorImage.Labels = make(map[string]string)


### PR DESCRIPTION
…es for internal disconnected testing

related to https://bugzilla.redhat.com/show_bug.cgi?id=1738476 and mirroring the jenkins imagestreams and samples operator registry host override for disconnected testing using 

@openshift/openshift-team-developer-experience @xiuwang  fyi

/assign @bparees 