### PR TITLE
Bug 1742907: Degraded missing reason detail 41

### DIFF
--- a/pkg/apis/samples/v1/types.go
+++ b/pkg/apis/samples/v1/types.go
@@ -322,10 +322,12 @@ func (s *Config) ClearNameInReason(reason, name string) string {
 }
 
 const (
-	noInstallDetailed = "Samples installation in error at %s: %s"
-	installed         = "Samples installation successful at %s"
-	moving            = "Samples processing to %s"
-	removing          = "Deleting samples at %s"
+	noInstallDetailed  = "Samples installation in error at %s: %s"
+	installed          = "Samples installation successful at %s"
+	moving             = "Samples processing to %s"
+	removing           = "Deleting samples at %s"
+	doneImportsFailed  = "Samples installed at %s, with image import failures, see samples operator config object"
+	failedImageImports = "FailedImageImports"
 )
 
 // ClusterOperatorStatusAvailableCondition return values are as follows:
@@ -393,11 +395,6 @@ func (s *Config) ClusterOperatorStatusFailingCondition() (configv1.ConditionStat
 			"image pull credentials needed",
 			fmt.Sprintf(noInstallDetailed, os.Getenv("RELEASE_VERSION"), s.Condition(ImportCredentialsExist).Message)
 	}
-	/*if s.ConditionTrue(ImportImageErrorsExist) {
-		return trueRC,
-			"image import problem",
-			fmt.Sprintf(noInstallDetailed, os.Getenv("RELEASE_VESION"), s.Condition(ImportImageErrorsExist).Message)
-	}*/
 	// right now, any condition being unknown is indicative of a failure
 	// condition, either api server interaction or file system interaction;
 	// Conversely, those errors result in a ConditionUnknown setting on one
@@ -418,20 +415,27 @@ func (s *Config) ClusterOperatorStatusFailingCondition() (configv1.ConditionStat
 // and the following return values:
 // 1) is the value to set on the ClusterOperator Progressing condition
 // 2) string is the message to set on the condition
-func (s *Config) ClusterOperatorStatusProgressingCondition(failingState string, available configv1.ConditionStatus) (configv1.ConditionStatus, string) {
+// 3) string is the reason to set on the condition if needed
+func (s *Config) ClusterOperatorStatusProgressingCondition(failingState string, available configv1.ConditionStatus) (configv1.ConditionStatus, string, string) {
 	if len(failingState) > 0 {
-		return configv1.ConditionTrue, fmt.Sprintf(noInstallDetailed, os.Getenv("RELEASE_VERSION"), failingState)
+		return configv1.ConditionTrue, fmt.Sprintf(noInstallDetailed, os.Getenv("RELEASE_VERSION"), failingState), ""
 	}
 	if s.ConditionTrue(ImageChangesInProgress) {
-		return configv1.ConditionTrue, fmt.Sprintf(moving, os.Getenv("RELEASE_VERSION"))
+		return configv1.ConditionTrue, fmt.Sprintf(moving, os.Getenv("RELEASE_VERSION")), ""
 	}
 	if s.ConditionTrue(RemovePending) {
-		return configv1.ConditionTrue, fmt.Sprintf(removing, s.Status.Version)
+		return configv1.ConditionTrue, fmt.Sprintf(removing, s.Status.Version), ""
 	}
 	if available == configv1.ConditionTrue {
-		return configv1.ConditionFalse, fmt.Sprintf(installed, s.Status.Version)
+		msg := fmt.Sprintf(installed, s.Status.Version)
+		reason := ""
+		if s.ConditionTrue(ImportImageErrorsExist) {
+			msg = fmt.Sprintf(doneImportsFailed, s.Status.Version)
+			reason = failedImageImports
+		}
+		return configv1.ConditionFalse, msg, reason
 	}
-	return configv1.ConditionFalse, ""
+	return configv1.ConditionFalse, "", ""
 }
 
 // ClusterNeedsCreds checks the conditions that drive whether the operator complains about

--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -64,6 +64,7 @@ func (o *ClusterOperatorHandler) UpdateOperatorStatus(cfg *v1.Config) error {
 	err = o.setOperatorStatus(configv1.OperatorDegraded,
 		failing,
 		msgForFailing,
+		"",
 		"")
 	if err != nil {
 		return err
@@ -75,23 +76,25 @@ func (o *ClusterOperatorHandler) UpdateOperatorStatus(cfg *v1.Config) error {
 	err = o.setOperatorStatus(configv1.OperatorAvailable,
 		available,
 		msgForAvailable,
-		cfg.Status.Version)
+		cfg.Status.Version,
+		"")
 	if err != nil {
 		return err
 	}
 
-	progressing, msgForProgressing := cfg.ClusterOperatorStatusProgressingCondition(msgForProgressing, available)
+	progressing, msgForProgressing, reasonForProgressing := cfg.ClusterOperatorStatusProgressingCondition(msgForProgressing, available)
 	err = o.setOperatorStatus(configv1.OperatorProgressing,
 		progressing,
 		msgForProgressing,
-		"")
+		"",
+		reasonForProgressing)
 	if err != nil {
 		return nil
 	}
 	return nil
 }
 
-func (o *ClusterOperatorHandler) setOperatorStatus(condtype configv1.ClusterStatusConditionType, status configv1.ConditionStatus, msg, currentVersion string) error {
+func (o *ClusterOperatorHandler) setOperatorStatus(condtype configv1.ClusterStatusConditionType, status configv1.ConditionStatus, msg, currentVersion, reason string) error {
 	logrus.Debugf("setting clusteroperator status condition %s to %s with version %s", condtype, status, currentVersion)
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		state, err := o.ClusterOperatorWrapper.Get(ClusterOperatorName)
@@ -134,6 +137,7 @@ func (o *ClusterOperatorHandler) setOperatorStatus(condtype configv1.ClusterStat
 				Type:               condtype,
 				Status:             status,
 				Message:            msg,
+				Reason:             reason,
 				LastTransitionTime: metaapi.Now(),
 			})
 
@@ -143,6 +147,7 @@ func (o *ClusterOperatorHandler) setOperatorStatus(condtype configv1.ClusterStat
 			Type:               condtype,
 			Status:             status,
 			Message:            msg,
+			Reason:             reason,
 			LastTransitionTime: metaapi.Now(),
 		})
 

--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -60,12 +60,12 @@ type ClusterOperatorWrapper interface {
 
 func (o *ClusterOperatorHandler) UpdateOperatorStatus(cfg *v1.Config) error {
 	var err error
-	failing, msgForProgressing, msgForFailing := cfg.ClusterOperatorStatusFailingCondition()
+	failing, failingReason, failingDetail := cfg.ClusterOperatorStatusFailingCondition()
 	err = o.setOperatorStatus(configv1.OperatorDegraded,
 		failing,
-		msgForFailing,
+		failingDetail,
 		"",
-		"")
+		failingReason)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (o *ClusterOperatorHandler) UpdateOperatorStatus(cfg *v1.Config) error {
 		return err
 	}
 
-	progressing, msgForProgressing, reasonForProgressing := cfg.ClusterOperatorStatusProgressingCondition(msgForProgressing, available)
+	progressing, msgForProgressing, reasonForProgressing := cfg.ClusterOperatorStatusProgressingCondition(failingReason, available)
 	err = o.setOperatorStatus(configv1.OperatorProgressing,
 		progressing,
 		msgForProgressing,


### PR DESCRIPTION
the automatic cherry-pick from the last 4.2 PR did not work:  https://github.com/openshift/cluster-samples-operator/pull/167#issuecomment-522238466

that said, two commits from 4.2 were needed to fix missing reason details for cluster operator conditions for the samples operator - those commits were picked 

but also, @bparees and I previously discussed that we should *NOT* backport the "feature" around marking samples operator degraded if imagestream imports have been failing for two hours

as such, some of the changes from the two 4.2 PRs were dropped

/assign @bparees (as we discussed various particulars of what to merge back in https://bugzilla.redhat.com/show_bug.cgi?id=1741069)
@openshift/openshift-team-developer-experience fyi