### PR TITLE
Bug 1746342: clean up available/progressing/degraded, including new msg/reason, wh…

### DIFF
--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -60,29 +60,29 @@ type ClusterOperatorWrapper interface {
 
 func (o *ClusterOperatorHandler) UpdateOperatorStatus(cfg *v1.Config) error {
 	var err error
-	failing, failingReason, failingDetail := cfg.ClusterOperatorStatusFailingCondition()
+	degraded, degradedReason, degradedDetail := cfg.ClusterOperatorStatusDegradedCondition()
 	err = o.setOperatorStatus(configv1.OperatorDegraded,
-		failing,
-		failingDetail,
+		degraded,
+		degradedDetail,
 		"",
-		failingReason)
+		degradedReason)
 	if err != nil {
 		return err
 	}
 
-	available, msgForAvailable := cfg.ClusterOperatorStatusAvailableCondition()
+	available, reasonForAvailable, msgForAvailable := cfg.ClusterOperatorStatusAvailableCondition()
 	// if we're setting the operator status to available, also set the operator version
 	// to the current version.
 	err = o.setOperatorStatus(configv1.OperatorAvailable,
 		available,
 		msgForAvailable,
 		cfg.Status.Version,
-		"")
+		reasonForAvailable)
 	if err != nil {
 		return err
 	}
 
-	progressing, msgForProgressing, reasonForProgressing := cfg.ClusterOperatorStatusProgressingCondition(failingReason, available)
+	progressing, reasonForProgressing, msgForProgressing := cfg.ClusterOperatorStatusProgressingCondition(degradedReason, available)
 	err = o.setOperatorStatus(configv1.OperatorProgressing,
 		progressing,
 		msgForProgressing,

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -828,7 +828,7 @@ func TestImageStreamImportError(t *testing.T) {
 			importErr.LastTransitionTime = metav1.Now()
 		}
 		cfg.ConditionUpdate(importErr)
-		status, reason, detail := cfg.ClusterOperatorStatusFailingCondition()
+		status, reason, detail := cfg.ClusterOperatorStatusDegradedCondition()
 		if (status != configv1.ConditionTrue && turnBackThreeHours) || (status == configv1.ConditionTrue && !turnBackThreeHours) {
 			t.Fatalf("image import error from %#v not reflected in cluster status %#v", is, cfg)
 		}


### PR DESCRIPTION
…en unmanaged/removed

@openshift/openshift-team-developer-experience PTAL based on cycles available

/assign @bparees 
(given the "broader discussion" on proper conventions for clusteroperator conventions when unmanaged/removed)

@bparees assuming everyone is OK with these changes given current assumptions, do we want to merge this before any "broader discussions"