### PR TITLE
add list of imagestreams failing import to progressing/degraded detailed message

### DIFF
--- a/pkg/apis/samples/v1/types.go
+++ b/pkg/apis/samples/v1/types.go
@@ -334,7 +334,7 @@ const (
 	installedButNotManaged = "Samples installation was previously successful at %s but the samples operator is now %s"
 	moving                 = "Samples processing to %s"
 	removing               = "Deleting samples at %s"
-	doneImportsFailed      = "Samples installed at %s, with image import failures, see samples operator config object"
+	doneImportsFailed      = "Samples installed at %s, with image import failures for these imagestreams: %s"
 	failedImageImports     = "FailedImageImports"
 	currentlyNotManaged    = "Currently%s"
 )
@@ -421,7 +421,7 @@ func (s *Config) ClusterOperatorStatusDegradedCondition() (configv1.ConditionSta
 		now := metav1.Now()
 		twoHrsAgo := now.Time.Add(-2 * time.Hour)
 		if impErrCon.LastTransitionTime.Time.Before(twoHrsAgo) {
-			msg := fmt.Sprintf(doneImportsFailed, s.Status.Version)
+			msg := fmt.Sprintf(doneImportsFailed, s.Status.Version, impErrCon.Reason)
 			return trueRC, failedImageImports, msg
 		}
 
@@ -470,7 +470,8 @@ func (s *Config) ClusterOperatorStatusProgressingCondition(degradedState string,
 		msg := fmt.Sprintf(installed, s.Status.Version)
 		reason := ""
 		if s.ConditionTrue(ImportImageErrorsExist) {
-			msg = fmt.Sprintf(doneImportsFailed, s.Status.Version)
+			importErrors := s.Condition(ImportImageErrorsExist)
+			msg = fmt.Sprintf(doneImportsFailed, s.Status.Version, importErrors.Reason)
 			reason = failedImageImports
 		}
 		return configv1.ConditionFalse, reason, msg


### PR DESCRIPTION
in service of extended test flake https://bugzilla.redhat.com/show_bug.cgi?id=1745418

adding the specific imagestream import failures in the detailed message for clusteroperator detailed/progressing conditions is more useful then pointing admins to the config object

also, we can check in our extended tests to see which imagestreams failed when determining whether the test run is safe to continue  ... I'll be submitting a openshift/origin PR that does that and resolves https://bugzilla.redhat.com/show_bug.cgi?id=1745418 after this merges 

/assign @adambkaplan 
@openshift/openshift-team-developer-experience  FYI