### PR TITLE
Bug 1749152: close gaps for updating clusteroperator during delete of config object

### DIFF
--- a/pkg/stub/templates.go
+++ b/pkg/stub/templates.go
@@ -30,6 +30,9 @@ func (h *Handler) processTemplateWatchEvent(t *templatev1.Template, deleted bool
 	if !doUpsert {
 		return nil
 	}
+	if cfg == nil {
+		return nil
+	}
 
 	template, err := h.Filetemplategetter.Get(filePath)
 	if err != nil {


### PR DESCRIPTION
/assign @bparees 
/assign @adambkaplan 
@openshift/openshift-team-developer-experience 

among other things, if we were in the middle of imagestream imports when the delete occurred, I could see *SOME* delays though not 5 minutes

but there may have been some missed opportunities to update the condition because the code did not think it was modified

also adding some more proactive updating and some removal of retry on samples events 