### PR TITLE
config: Bump from v1alpha1 to v1

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,3 @@
-apiVersion: samplesoperator.config.openshift.io/v1alpha1
+apiVersion: samplesoperator.config.openshift.io/v1
 kind: SamplesResource
 projectName: cluster-samples-operator

--- a/tmp/codegen/update-generated.sh
+++ b/tmp/codegen/update-generated.sh
@@ -8,5 +8,5 @@ vendor/k8s.io/code-generator/generate-groups.sh \
 deepcopy \
 github.com/openshift/cluster-samples-operator/pkg/generated \
 github.com/openshift/cluster-samples-operator/pkg/apis \
-samplesoperator:v1alpha1 \
+samplesoperator:v1 \
 --go-header-file "./tmp/codegen/boilerplate.go.txt"


### PR DESCRIPTION
Also update `update-generated.sh`.  Catching up with 51c1b577c1 (#75).

I don't really know what either of the files I'm touching are for, so feel free to close if this makes no sense ;).