### PR TITLE
Bug 1755115: turn on scheduled import for payload imagestreams not managed by samp…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ cluster-samples-operator
 tmp/_output
 tmp/_test
 
+vendor/bin
+vendor/pkg
+
+*.classpath
+*.project
+*.settings
 
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 

--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   tags:
   - name: latest
+    importPolicy:
+      scheduled: true
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cli:v4.0
@@ -21,6 +23,8 @@ metadata:
 spec:
   tags:
   - name: latest
+    importPolicy:
+      scheduled: true
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cli-artifacts:v4.0
@@ -33,6 +37,8 @@ metadata:
 spec:
   tags:
   - name: latest
+    importPolicy:
+      scheduled: true
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-installer:v4.0
@@ -45,6 +51,8 @@ metadata:
 spec:
   tags:
   - name: latest
+    importPolicy:
+      scheduled: true
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-installer-artifacts:v4.0
@@ -57,6 +65,8 @@ metadata:
 spec:
   tags:
   - name: latest
+    importPolicy:
+      scheduled: true
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-tests:v4.0
@@ -69,6 +79,8 @@ metadata:
 spec:
   tags:
     - name: latest
+      importPolicy:
+        scheduled: true
       from:
         kind: DockerImage
         name: quay.io/openshift/origin-must-gather:v4.0


### PR DESCRIPTION
…les operator

/hold

@smarterclayton @bparees @adambkaplan @dmage I'll launch a cluster via cluster-bot from this PR after the e2e's run, and see what the imagestream statuses look like in real time.