### PR TITLE
Bug 1771321: no longer gate setting progressing to false on in flight imagestream …

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ The samples resource maintains the following conditions in its status:
 - SamplesExists
 -- Indicates the samples have been created in the openshift namespace
 - ImageChangesInProgress
--- True when imagestreams have been created/updated, but not all of the tag spec generations and tag status generations match
--- False when all of the generations match, or unrecoverable errors occurred during import … the last seen error will be in the message field
+-- True when imagestreams have been created/updated, but we are awaiting acknowledgment all the changes were applied  
+-- False when all imagestream changes are acknowledged 
 -- The list of pending imagestreams will be in the reason field
 - ImportCredentialsExist
 -- A 'samples-registry-credentials' secret has been copied into the openshift namespace

--- a/pkg/stub/imagestreams.go
+++ b/pkg/stub/imagestreams.go
@@ -350,7 +350,7 @@ func (h *Handler) clearStreamFromImportError(name string, importError *v1.Config
 }
 
 func (h *Handler) processImportStatus(is *imagev1.ImageStream, cfg *v1.Config) (*v1.Config, string, bool) {
-	pending := false
+	//pending := false
 	anyErrors := false
 	importError := cfg.Condition(v1.ImportImageErrorsExist)
 	nonMatchDetail := ""
@@ -443,7 +443,7 @@ func (h *Handler) processImportStatus(is *imagev1.ImageStream, cfg *v1.Config) (
 			}
 		}
 
-		if !anyErrors {
+		/*if !anyErrors {
 			// it is possible after an upgrade that tags can be removed because of EOL processing;
 			// since we do not delete those EOL images from the imagestream status (so as to not break
 			// existing deployments referencing specific tags), it is possible that a valid configuration
@@ -497,7 +497,7 @@ func (h *Handler) processImportStatus(is *imagev1.ImageStream, cfg *v1.Config) (
 				pending = true
 				nonMatchDetail = "the number of status tags is less than the number of spec tags"
 			}
-		}
+		}*/
 	} else {
 		logrus.Debugf("no error/progress checks cause stream %s is skipped", is.Name)
 		// but if skipped, clear out any errors, since we do not care about errors for skipped
@@ -506,10 +506,11 @@ func (h *Handler) processImportStatus(is *imagev1.ImageStream, cfg *v1.Config) (
 
 	processing := cfg.Condition(v1.ImageChangesInProgress)
 
-	logrus.Debugf("pending is %v any errors %v for %s", pending, anyErrors, is.Name)
+	//logrus.Debugf("pending is %v any errors %v for %s", pending, anyErrors, is.Name)
+	logrus.Debugf("any errors %v for %s", anyErrors, is.Name)
 
 	// we check for processing == true here as well to avoid churn on relists
-	if !pending {
+	//if !pending {
 		if !anyErrors {
 			h.clearStreamFromImportError(is.Name, importError, cfg)
 		}
@@ -533,7 +534,7 @@ func (h *Handler) processImportStatus(is *imagev1.ImageStream, cfg *v1.Config) (
 				anyConditionUpdate = true
 			}
 		}
-	}
+	//}
 
 	// clear out error for this stream if there were errors previously but no longer are
 	// think a scheduled import failing then recovering


### PR DESCRIPTION
…image import (facilitate disconnected scenarios)

end of an era for samples operator  ( :-) or :-( depending on your point of view )

/assign @bparees 
@openshift/openshift-team-developer-experience FYI

I've commented out vs. deleted, at least for now (to make revisiting a bit easier ... but I won't object to deleting now vs. later if folks want that)

@bmcelvee - we will want to change https://docs.openshift.com/container-platform/4.2/openshift_images/configuring-samples-operator.html#conditions to line up with the README changes here ... do you need me to craft a PR or can you do it?