### PR TITLE
Bug 1778613: Java's tag name should contain only version

### DIFF
--- a/tmp/build/assets/operator/ocp-x86_64/java/imagestreams/java-rhel7.json
+++ b/tmp/build/assets/operator/ocp-x86_64/java/imagestreams/java-rhel7.json
@@ -67,7 +67,7 @@
                 },
                 "from": {
                     "kind": "ImageStreamTag",
-                    "name": "java:11"
+                    "name": "11"
                 },
                 "name": "latest",
                 "referencePolicy": {


### PR DESCRIPTION
All tag names in the ImageStream that point to an 'ImageStreamTag' should contain only the version.

/assign @gabemontero 