### PR TITLE
Bug 1788612: temp disable of openjdk-8-11 while it seems busted on registry.redhat.io

### DIFF
--- a/tmp/build/assets/operator/ocp-x86_64/java/imagestreams/openjdk-8-rhel8-rhel7.json
+++ b/tmp/build/assets/operator/ocp-x86_64/java/imagestreams/openjdk-8-rhel8-rhel7.json
@@ -32,25 +32,6 @@
                 "referencePolicy": {
                     "type": "Local"
                 }
-            },
-            {
-                "annotations": {
-                    "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
-                    "iconClass": "icon-rh-openjdk",
-                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
-                    "sampleContextDir": "undertow-servlet",
-                    "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                    "tags": "builder,java,openjdk,ubi8,hidden",
-                    "version": "1.1"
-                },
-                "from": {
-                    "kind": "DockerImage",
-                    "name": "registry.redhat.io/openjdk/openjdk-1.8-rhel8:1.1"
-                },
-                "name": "1.1",
-                "referencePolicy": {
-                    "type": "Local"
-                }
             }
         ]
     }


### PR DESCRIPTION
I've seen the import fail in multiple installs since last Friday, as have others in 4-dev-triage, etc. and docker pulls from my laptop are proving very very flaky

@openshift/openshift-team-developer-experience @bparees fyi

/assign @adambkaplan 

after this merges I'll craft a re-enablement PR and between that and local pulls see if/when it stabilizes

it is still listed as a valid option in the container catalog