### PR TITLE
[release-4.2] Bug 1805615: no longer gate removed processing when imagestreams in progress

### DIFF
--- a/pkg/apis/samples/v1/types.go
+++ b/pkg/apis/samples/v1/types.go
@@ -474,7 +474,7 @@ func (s *Config) ClusterOperatorStatusProgressingCondition(degradedState string,
 		return configv1.ConditionTrue, "", fmt.Sprintf(moving, os.Getenv("RELEASE_VERSION"))
 	}
 	if s.ConditionTrue(RemovePending) {
-		return configv1.ConditionTrue, "", fmt.Sprintf(removing, s.Status.Version)
+		return configv1.ConditionTrue, "", fmt.Sprintf(removing, os.Getenv("RELEASE_VERSION"))
 	}
 	if available == configv1.ConditionTrue {
 		msg := fmt.Sprintf(installed, s.Status.Version)

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -170,16 +170,14 @@ func (h *Handler) prepSamplesWatchEvent(kind, name string, annotations map[strin
 		return nil, "", false, nil
 	}
 
-	if cfg.ConditionFalse(v1.ImageChangesInProgress) {
-		// we do no return the cfg in these cases because we do not want to bother with any progress tracking
-		switch cfg.Spec.ManagementState {
-		case operatorsv1api.Removed:
-			logrus.Debugf("Not upserting %s/%s event because operator is in removed state and image changes are not in progress", kind, name)
-			return nil, "", false, nil
-		case operatorsv1api.Unmanaged:
-			logrus.Debugf("Not upserting %s/%s event because operator is in unmanaged state and image changes are not in progress", kind, name)
-			return nil, "", false, nil
-		}
+	// we do not return the cfg in these cases because we do not want to bother with any progress tracking
+	switch cfg.Spec.ManagementState {
+	case operatorsv1api.Removed:
+		logrus.Debugf("Not upserting %s/%s event because operator is in removed state and image changes are not in progress", kind, name)
+		return nil, "", false, nil
+	case operatorsv1api.Unmanaged:
+		logrus.Debugf("Not upserting %s/%s event because operator is in unmanaged state and image changes are not in progress", kind, name)
+		return nil, "", false, nil
 	}
 
 	filePath := ""
@@ -592,7 +590,7 @@ func (h *Handler) Handle(event v1.Event) error {
 		if !doit || err != nil {
 			if err != nil || cfgUpdate {
 				// flush status update
-				dbg := "process mgmt update"
+				dbg := fmt.Sprintf("process mgmt update spec %s status %s", string(cfg.Spec.ManagementState), string(cfg.Status.ManagementState))
 				logrus.Printf("CRDUPDATE %s", dbg)
 				return h.crdwrapper.UpdateStatus(cfg, dbg)
 			}

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -186,38 +186,27 @@ func TestManagementState(t *testing.T) {
 	cfg.ResourceVersion = "3"
 	cfg.Spec.ManagementState = operatorsv1api.Removed
 	err = h.Handle(event)
+	// RemovePending now true
 	statuses[4] = corev1.ConditionTrue
 	validate(true, err, "", cfg, conditions, statuses, t)
 	if cfg.Status.ManagementState == operatorsv1api.Removed {
 		t.Fatalf("cfg status set to removed too early %#v", cfg)
 	}
 
-	// verify while we are image in progress and the remove on hold setting is still set to true
-	// if another event comes in
+	// verify while we are image in progress no false and the remove on hold setting is still set to true
 	cfg.ResourceVersion = "4"
 	err = h.Handle(event)
-	validate(true, err, "", cfg, conditions, statuses, t)
-	if cfg.Status.ManagementState == operatorsv1api.Removed {
-		t.Fatalf("cfg status set to removed too early %#v", cfg)
-	}
-
-	// mimic when in progress set to false by imagestream watch
-	// then analyze resulting Config event
-	progressing := cfg.Condition(v1.ImageChangesInProgress)
-	progressing.Status = corev1.ConditionFalse
-	progressing.Reason = ""
-	cfg.ConditionUpdate(progressing)
-	cfg.ResourceVersion = "5"
-	err = h.Handle(event)
-	// index 0 samples exist should be false
+	// SamplesExists, ImageChangesInProgress, ImportImageErrorsExists all false
 	statuses[0] = corev1.ConditionFalse
-	// in progress should be false
 	statuses[3] = corev1.ConditionFalse
+	statuses[6] = corev1.ConditionFalse
 	validate(true, err, "", cfg, conditions, statuses, t)
 	if cfg.Status.ManagementState != operatorsv1api.Removed {
-		t.Fatalf("cfg status not set to removed %#v", cfg)
+		t.Fatalf("cfg status should have been set to removed %#v", cfg)
 	}
-	cfg.ResourceVersion = "6"
+
+	cfg.ResourceVersion = "5"
+	err = h.Handle(event)
 	// remove pending should be false
 	statuses[4] = corev1.ConditionFalse
 	err = h.Handle(event)


### PR DESCRIPTION
Manual pick of https://github.com/openshift/cluster-samples-operator/pull/220 for 4.2.z

cherrypick bot failed ..... see https://github.com/openshift/cluster-samples-operator/pull/220#issuecomment-589697147