### PR TITLE
create metric/alert around sample boostrapping as removed for inacces…

### DIFF
--- a/manifests/010-prometheus-rules.yaml
+++ b/manifests/010-prometheus-rules.yaml
@@ -41,3 +41,11 @@ spec:
       annotations:
         message: |
           Samples operator cannot find credentials for 'registry.redhat.io' in the samples pull secret in the openshift namespace.  Unless you have updated the 'samplesRegistry' field in the samples operator config to change which registry the sample ImageStreams are pulled from, you will have failed imports for many of the sample ImageStreams in this case.
+    - alert: SamplesTBRInaccessibleOnBoot
+      expr: openshift_samples_tbr_inaccessible_info == 1
+      for: 2d
+      labels:
+        severity: info
+      annotations:
+        message: |
+          Samples operator could not access regsitry.redhat.io during its initial installation and it boostrapped as removed.

--- a/manifests/010-prometheus-rules.yaml
+++ b/manifests/010-prometheus-rules.yaml
@@ -48,4 +48,4 @@ spec:
         severity: info
       annotations:
         message: |
-          Samples operator could not access regsitry.redhat.io during its initial installation and it boostrapped as removed.
+          Samples operator could not access 'regsitry.redhat.io' during its initial installation and it boostrapped as removed.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -60,7 +60,7 @@ var (
 	})
 	tbrInaccessibleOnBootStat = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: tbrInaccessibleOnBootstrapQuery,
-		Help: "Indicates that during its initial installation the samples operator could not access registry.redhat.com and it boostrapped as removed.",
+		Help: "Indicates that during its initial installation the samples operator could not access registry.redhat.io and it boostrapped as removed.",
 	})
 
 	sc         = samplesCollector{}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -34,6 +34,8 @@ const (
 	missingSecret        = "missing_secret"
 	missingTBRCredential = "missing_tbr_credential"
 
+	tbrInaccessibleOnBootstrapQuery = "openshift_samples_tbr_inaccessible_info"
+
 	// MetricsPort is the IP port supplied to the HTTP server used for prometheus,
 	// and matches what is specified in the corresponding Service and ServiceMonitor
 	MetricsPort = 60000
@@ -55,6 +57,10 @@ var (
 	configInvalidStat = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: invalidConfigQuery,
 		Help: "Indicates the configuration for the samples operator has an invalid configuration setting.",
+	})
+	tbrInaccessibleOnBootStat = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: tbrInaccessibleOnBootstrapQuery,
+		Help: "Indicates that during its initial installation the samples operator could not access registry.redhat.com and it boostrapped as removed.",
 	})
 
 	sc         = samplesCollector{}
@@ -176,7 +182,7 @@ func addCountGauge(ch chan<- prometheus.Metric, desc *prometheus.Desc, name stri
 }
 
 func init() {
-	prometheus.MustRegister(degradedStat, configInvalidStat)
+	prometheus.MustRegister(degradedStat, configInvalidStat, tbrInaccessibleOnBootStat)
 }
 
 func InitializeMetricsCollector(listers *client.Listers) {

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -73,3 +73,11 @@ func ConfigInvalid(inv bool) {
 	}
 	configInvalidStat.Set(0)
 }
+
+func TBRInaccessibleOnBoot(badTBR bool) {
+	if badTBR {
+		tbrInaccessibleOnBootStat.Set(1)
+		return
+	}
+	tbrInaccessibleOnBootStat.Set(0)
+}

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -106,6 +106,10 @@ func TestBinaryMetrics(t *testing.T) {
 			method: ConfigInvalid,
 			query:  invalidConfigQuery,
 		},
+		{
+			method: TBRInaccessibleOnBoot,
+			query: tbrInaccessibleOnBootstrapQuery,
+		},
 	} {
 		for _, tt := range []struct {
 			name string

--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -97,8 +97,10 @@ func (o *ClusterOperatorHandler) UpdateOperatorStatus(cfg *v1.Config, deletionIn
 	}
 	if tbrInaccessible {
 		o.setOperatorStatusWithoutInterrogatingConfig(configv1.ConditionFalse, cfg, TBR)
+		metrics.TBRInaccessibleOnBoot(true)
 		return nil
 	}
+	metrics.TBRInaccessibleOnBoot(false)
 
 	errs := []error{}
 	degraded, degradedReason, degradedDetail := util.ClusterOperatorStatusDegradedCondition(cfg)


### PR DESCRIPTION
…sbile tbr

It occurred to me soon after dropping the ipv6/disconnected bootstrap as removed enhancement, some metrics around not being able to access `registry.redhat.io` might be usefule

Though it did not occur to me until after feature freeze

Here it is now that 4.5 has opened up

@openshift/openshift-team-developer-experience @bparees FYI

/assign @adambkaplan 

If folks are really opposed to this in general I won't push back and will just close/delete