### PR TITLE
manifests: Add the new 'tools' image as an image stream for debug

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -75,6 +75,20 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
   namespace: openshift
+  name: tools
+spec:
+  tags:
+  - name: latest
+    importPolicy:
+      scheduled: true
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-tools:v4.0
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
   name: must-gather
 spec:
   tags:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -42,6 +42,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-tests:v4.0
+  - name: tools
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-tools:v4.0
   - name: must-gather
     from:
       kind: DockerImage


### PR DESCRIPTION
The tools image is the base for 'tests' and will be used by default
for debug, ensuring that admins get a fast and quick deploy (because
the base image is reused). We will add necessary administrative tools
to the image over time to ensure admins are happy.

/hold

until the image is available in OSBS and the nightly streams