### PR TITLE
Bug 1822381: revert pr 177; no override jenkins* registry hosts for mirrors

### DIFF
--- a/pkg/stub/imagestreams.go
+++ b/pkg/stub/imagestreams.go
@@ -267,6 +267,16 @@ func (h *Handler) upsertImageStream(imagestreamInOperatorImage, imagestreamInClu
 
 func (h *Handler) updateDockerPullSpec(oldies []string, imagestream *imagev1.ImageStream, opcfg *v1.Config) {
 	logrus.Debugf("updateDockerPullSpec stream %s has repo %s", imagestream.Name, imagestream.Spec.DockerImageRepository)
+	// we always want to leave the jenkins images as using the payload set to the IMAGE* env's;
+	switch imagestream.Name {
+	case "jenkins":
+		return
+	case "jenkins-agent-nodejs":
+		return
+	case "jenkins-agent-maven":
+		return
+	}
+
 	// don't mess with deprecated field unless it is actually set with something
 	if len(imagestream.Spec.DockerImageRepository) > 0 &&
 		!strings.HasPrefix(imagestream.Spec.DockerImageRepository, opcfg.Spec.SamplesRegistry) {


### PR DESCRIPTION
Details in bz, but with import stream via sha in, we don't need to override the jenkins image stream registry to support disconnected, and that gets in the way in other scenarios

@openshift/openshift-team-developer-experience fyi

/assign @bparees 

see https://github.com/openshift/cluster-samples-operator/pull/177