### PR TITLE
Bug 1828065: correctly handle removed templates watch events as part of an upgrade

### DIFF
--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -636,6 +636,23 @@ func setup() (Handler, *v1.Config, util.Event) {
 	return h, cfg, util.Event{Object: cfg}
 }
 
+func TestTemplateRemovedFromPayload(t *testing.T) {
+	h, _, _ := setup()
+	mimic(&h, x86OCPContentRootDir)
+
+	_, filePath, doUpsert, updateCfgOnly, err := h.prepSamplesWatchEvent("template", "no-longer-exists", map[string]string{}, false)
+	switch {
+	case len(filePath) > 0:
+		t.Fatalf("should not have returned a file path")
+	case doUpsert:
+		t.Fatalf("do upsert should not be true")
+	case updateCfgOnly:
+		t.Fatalf("update cfg only should not be true")
+	case err != nil:
+		t.Fatalf("got unexpected err %s", err.Error())
+	}
+}
+
 func TestImageStreamRemovedFromPayloadWithProgressingErrors(t *testing.T) {
 	h, cfg, _ := setup()
 	mimic(&h, x86OCPContentRootDir)


### PR DESCRIPTION
basically https://github.com/openshift/cluster-samples-operator/pull/240 was incomplete with respect to samples that are removed from release to release

there is a window where removed templates can gum up the works where repeated attempts to process removed templates result in repeated 

```
time="2020-04-27T06:43:12Z" level=info msg="open : no such file or directory error reading file []"
time="2020-04-27T06:43:12Z" level=info msg="CRDUPDATE event temp udpate err"
```

which leads to a storm of addtional updates to the samples operator config object 
that can severely slow down getting the progressing condition to false

/assign @bparees 
/assign @adambkaplan 

@bparees I assigned you in case you want this expedited and included in 4.4.0 ... I'm guessing the answer to that is "no" based on the current state of the 4.4.0 upgrade BZ bugs but I did not want to assume.  Feel free to unassign / comment as you deem fit.  Thanks.