### PR TITLE
Bug 1832344: correctly handle removed templates watch events as part of an upgrade

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -122,12 +122,12 @@ type Handler struct {
 	templateclientwrapper TemplateClientWrapper
 	secretclientwrapper   SecretClientWrapper
 
-	crdlister           configv1lister.ConfigLister
-	streamlister        imagev1lister.ImageStreamNamespaceLister
-	tplstore            templatev1lister.TemplateNamespaceLister
+	crdlister        configv1lister.ConfigLister
+	streamlister     imagev1lister.ImageStreamNamespaceLister
+	tplstore         templatev1lister.TemplateNamespaceLister
 	opshiftsecretlister corev1lister.SecretNamespaceLister
-	cfgsecretlister     corev1lister.SecretNamespaceLister
-	opersecretlister    corev1lister.SecretNamespaceLister
+	cfgsecretlister  corev1lister.SecretNamespaceLister
+	opersecretlister corev1lister.SecretNamespaceLister
 
 	Fileimagegetter    ImageStreamFromFileGetter
 	Filetemplategetter TemplateFromFileGetter
@@ -187,8 +187,9 @@ func (h *Handler) prepSamplesWatchEvent(kind, name string, annotations map[strin
 
 	filePath := ""
 	// on pod restarts samples watch events come in before the first
-	// Config event, or we might not get an event at all if there were no changes,
-	// so build list here
+	// Config event, or we might not get an event at all if there were no changes;
+	// restarts as part of migrations also make things interesting because existing
+	// samples may have been deleted on disk, but we'll address that below
 	force := metrics.StreamsEmpty()
 	h.buildFileMaps(cfg, force)
 
@@ -200,42 +201,49 @@ func (h *Handler) prepSamplesWatchEvent(kind, name string, annotations map[strin
 	switch kind {
 	case "imagestream":
 		filePath, inInventory = h.imagestreamFile[name]
+		if !inInventory {
+			logrus.Printf("watch stream event %s not part of operators inventory", name)
+			// we now have cases where sample providers are deleting entire imagestreams;
+			// let's make sure there are no stale entries with inprogress / importerror
+			processing := util.Condition(cfg, v1.ImageChangesInProgress)
+			needToUpdate := util.NameInReason(cfg, processing.Reason, name)
+			if needToUpdate {
+				now := kapis.Now()
+				processing.Reason = util.ClearNameInReason(cfg, processing.Reason, name)
+				logrus.Debugf("processing reason now %s", processing.Reason)
+				if len(strings.TrimSpace(processing.Reason)) == 0 {
+					logrus.Println("The last in progress imagestream has completed (removed imagestream check)")
+					processing.Status = corev1.ConditionFalse
+					processing.Reason = ""
+					processing.LastTransitionTime = now
+				}
+				processing.LastUpdateTime = now
+				util.ConditionUpdate(cfg, processing)
+			}
+			importErrors := util.Condition(cfg, v1.ImportImageErrorsExist)
+			needToUpdate2 := util.NameInReason(cfg, importErrors.Reason, name)
+			if needToUpdate2 {
+				h.mapsMutex.Lock()
+				defer h.mapsMutex.Unlock()
+				h.clearStreamFromImportError(name, importErrors, cfg)
+			}
+			if needToUpdate || needToUpdate2 {
+				return cfg, "", false, true, nil
+			}
+			return nil, "", false, false, nil
+		}
 		_, skipped = h.skippedImagestreams[name]
 	case "template":
 		filePath, inInventory = h.templateFile[name]
+		if !inInventory {
+			// in the case of templates we can just ignore content from prior releases that is no longer
+			// part of the current release
+			logrus.Printf("watch template event %s not part of operators inventory", name)
+			return nil, "", false, false, nil
+		}
 		_, skipped = h.skippedTemplates[name]
 	}
-	if !inInventory && kind == "imagestream" {
-		logrus.Printf("watch event %s not part of operators inventory", name)
-		// we now have cases where sample providers are deleting entire imagestreams;
-		// let's make sure there are no stale entries with inprogress / importerror
-		processing := util.Condition(cfg, v1.ImageChangesInProgress)
-		needToUpdate := util.NameInReason(cfg, processing.Reason, name)
-		if needToUpdate {
-			now := kapis.Now()
-			processing.Reason = util.ClearNameInReason(cfg, processing.Reason, name)
-			logrus.Debugf("processing reason now %s", processing.Reason)
-			if len(strings.TrimSpace(processing.Reason)) == 0 {
-				logrus.Println("The last in progress imagestream has completed (removed imagestream check)")
-				processing.Status = corev1.ConditionFalse
-				processing.Reason = ""
-				processing.LastTransitionTime = now
-			}
-			processing.LastUpdateTime = now
-			util.ConditionUpdate(cfg, processing)
-		}
-		importErrors := util.Condition(cfg, v1.ImportImageErrorsExist)
-		needToUpdate2 := util.NameInReason(cfg, importErrors.Reason, name)
-		if needToUpdate2 {
-			h.mapsMutex.Lock()
-			defer h.mapsMutex.Unlock()
-			h.clearStreamFromImportError(name, importErrors, cfg)
-		}
-		if needToUpdate || needToUpdate2 {
-			return cfg, "", false, true, nil
-		}
-		return nil, "", false, false, nil
-	}
+
 	if skipped {
 		logrus.Printf("watch event %s in skipped list for %s", name, kind)
 		// but return cfg to potentially toggle pending/import error condition
@@ -762,10 +770,9 @@ func (h *Handler) Handle(event util.Event) error {
 					return h.crdwrapper.UpdateStatus(cfg, dbg)
 				}
 
-				// in case this is a bring up after initial install, we take a pass
-				// and see if any samples were deleted while samples operator was down
-				force := metrics.StreamsEmpty()
-				h.buildFileMaps(cfg, force)
+				// migration inevitably means we need to refresh the file cache as samples are added and
+				// deleted between releases, so force file map building
+				h.buildFileMaps(cfg, true)
 				// passing in false means if the samples is present, we leave it alone
 				_, err = h.createSamples(cfg, false, registryChanged, unskippedStreams, unskippedTemplates)
 				return err

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -788,6 +788,23 @@ func TestSecretAPIError(t *testing.T) {
 	validate(true, err, "", cfg, conditions, statuses, t)
 }
 
+func TestTemplateRemovedFromPayload(t *testing.T) {
+	h, _, _ := setup()
+	mimic(&h, x86OCPContentRootDir)
+
+	_, filePath, doUpsert, updateCfgOnly, err := h.prepSamplesWatchEvent("template", "no-longer-exists", map[string]string{}, false)
+	switch {
+	case len(filePath) > 0:
+		t.Fatalf("should not have returned a file path")
+	case doUpsert:
+		t.Fatalf("do upsert should not be true")
+	case updateCfgOnly:
+		t.Fatalf("update cfg only should not be true")
+	case err != nil:
+		t.Fatalf("got unexpected err %s", err.Error())
+	}
+}
+
 func TestImageStreamRemovedFromPayloadWithProgressingErrors(t *testing.T) {
 	h, cfg, _ := setup()
 	mimic(&h, x86OCPContentRootDir)


### PR DESCRIPTION
Had to initiate manual pick of https://github.com/openshift/cluster-samples-operator/pull/265 and https://github.com/openshift/cluster-samples-operator/pull/265/commits/803f09300a304c3977f79a90d8b32b29fe94bc7d into 4.4 after automanted cherrpick bot failed ... see https://github.com/openshift/cluster-samples-operator/pull/265#issuecomment-624698661 for that failure

In addition to normal motivations for back picking upgrade fixes, this problem came up during an apparent etcd breakdown -> openshift apiserver breakdown -> samples could not create/update imagestream/template breakdown that was worked via https://coreos.slack.com/archives/C0134TXLGG3/p1588759278000200 while I was out on bereavement

/assign @adambkaplan 

@vrutkovs FYI

