### PR TITLE
Bug 1835112: avoid listing file system content for unsupported architures

### DIFF
--- a/pkg/stub/config.go
+++ b/pkg/stub/config.go
@@ -180,6 +180,12 @@ func (h *Handler) buildFileMaps(cfg *v1.Config, forceRebuild bool) error {
 	defer h.mapsMutex.Unlock()
 	if len(h.imagestreamFile) == 0 || len(h.templateFile) == 0 || forceRebuild {
 		for _, arch := range cfg.Spec.Architectures {
+			if util.IsNonX86Arch(cfg) {
+				// file list error will occur below until we have samples for s390x/ppc64le
+				// callers to code appropriately no-op out as needed when no file system content
+				// exists for a given template/imagestream
+				continue
+			}
 			dir := h.GetBaseDir(arch, cfg)
 			files, err := h.Filefinder.List(dir)
 			if err != nil {


### PR DESCRIPTION
file list gets executed on s390x/ppc64le upgrade even when mgmt state removed

placeholder and potential backport candidate while we work on getting s390x/ppc64le samples into 4.5 and/or 4.6