### PR TITLE
Standardize go imports

### DIFF
--- a/cmd/cluster-samples-operator/main.go
+++ b/cmd/cluster-samples-operator/main.go
@@ -4,16 +4,16 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/openshift/cluster-samples-operator/pkg/metrics"
-	"github.com/openshift/cluster-samples-operator/pkg/operator"
-	"github.com/openshift/cluster-samples-operator/pkg/signals"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/openshift/library-go/pkg/operator/watchdog"
 
-	"github.com/spf13/cobra"
-
-	"github.com/sirupsen/logrus"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"github.com/openshift/cluster-samples-operator/pkg/metrics"
+	"github.com/openshift/cluster-samples-operator/pkg/operator"
+	"github.com/openshift/cluster-samples-operator/pkg/signals"
 )
 
 func printVersion() {

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -1,16 +1,16 @@
 package client
 
 import (
-	imagelisters "github.com/openshift/client-go/image/listers/image/v1"
-	templatelisters "github.com/openshift/client-go/template/listers/template/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
+	imagelisters "github.com/openshift/client-go/image/listers/image/v1"
 	sampoplisters "github.com/openshift/client-go/samples/listers/samples/v1"
+	templatelisters "github.com/openshift/client-go/template/listers/template/v1"
 )
 
 type Listers struct {
-	ConfigNamespaceSecrets    corelisters.SecretNamespaceLister
-	ImageStreams              imagelisters.ImageStreamNamespaceLister
-	Templates                 templatelisters.TemplateNamespaceLister
-	Config                    sampoplisters.ConfigLister
+	ConfigNamespaceSecrets corelisters.SecretNamespaceLister
+	ImageStreams           imagelisters.ImageStreamNamespaceLister
+	Templates              templatelisters.TemplateNamespaceLister
+	Config                 sampoplisters.ConfigLister
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -4,18 +4,17 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
 	corelisters "k8s.io/client-go/listers/core/v1"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	operatorv1 "github.com/openshift/api/operator/v1"
-
 	configv1 "github.com/openshift/api/samples/v1"
-	"github.com/openshift/cluster-samples-operator/pkg/client"
-	"github.com/openshift/cluster-samples-operator/pkg/util"
 	sampoplisters "github.com/openshift/client-go/samples/listers/samples/v1"
 
-	"github.com/sirupsen/logrus"
+	"github.com/openshift/cluster-samples-operator/pkg/client"
+	"github.com/openshift/cluster-samples-operator/pkg/util"
 )
 
 const (

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1 "github.com/openshift/api/samples/v1"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 type fakeSecretLister struct {

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-samples-operator/pkg/util"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -19,23 +18,21 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	imagev1 "github.com/openshift/api/image/v1"
+	sampopapi "github.com/openshift/api/samples/v1"
+	templatev1 "github.com/openshift/api/template/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	imageset "github.com/openshift/client-go/image/clientset/versioned"
 	imageinformers "github.com/openshift/client-go/image/informers/externalversions"
-
-	templatev1 "github.com/openshift/api/template/v1"
+	sampleclientv1 "github.com/openshift/client-go/samples/clientset/versioned"
+	sampopinformers "github.com/openshift/client-go/samples/informers/externalversions"
 	templateset "github.com/openshift/client-go/template/clientset/versioned"
 	templateinformers "github.com/openshift/client-go/template/informers/externalversions"
 
-	sampopapi "github.com/openshift/api/samples/v1"
-	sampleclientv1 "github.com/openshift/client-go/samples/clientset/versioned"
-	sampopinformers "github.com/openshift/client-go/samples/informers/externalversions"
 	sampcache "github.com/openshift/cluster-samples-operator/pkg/cache"
 	sampopclient "github.com/openshift/cluster-samples-operator/pkg/client"
-
 	operatorstatus "github.com/openshift/cluster-samples-operator/pkg/operatorstatus"
 	"github.com/openshift/cluster-samples-operator/pkg/stub"
-
-	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/cluster-samples-operator/pkg/util"
 )
 
 const (

--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -7,16 +7,15 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/api/errors"
+	metaapi "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
 
 	configv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/openshift/api/samples/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
-	v1 "github.com/openshift/api/samples/v1"
 	"github.com/openshift/cluster-samples-operator/pkg/metrics"
 	"github.com/openshift/cluster-samples-operator/pkg/util"
 )

--- a/pkg/stub/config.go
+++ b/pkg/stub/config.go
@@ -4,14 +4,17 @@ import (
 	"fmt"
 	"strings"
 
-	operatorsv1api "github.com/openshift/api/operator/v1"
-	v1 "github.com/openshift/api/samples/v1"
-	"github.com/openshift/cluster-samples-operator/pkg/metrics"
-	"github.com/openshift/cluster-samples-operator/pkg/util"
 	"github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kapis "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorsv1api "github.com/openshift/api/operator/v1"
+	v1 "github.com/openshift/api/samples/v1"
+
+	"github.com/openshift/cluster-samples-operator/pkg/metrics"
+	"github.com/openshift/cluster-samples-operator/pkg/util"
 )
 
 func (h *Handler) ClearStatusConfigForRemoved(cfg *v1.Config) {

--- a/pkg/stub/files.go
+++ b/pkg/stub/files.go
@@ -4,10 +4,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/openshift/api/samples/v1"
-	"github.com/openshift/cluster-samples-operator/pkg/metrics"
 	"github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/api/samples/v1"
+
+	"github.com/openshift/cluster-samples-operator/pkg/metrics"
 )
 
 // mutex for h.imagestreamFiles and h.templateFiles managed by caller h.buildFileMaps

--- a/pkg/stub/finalizer.go
+++ b/pkg/stub/finalizer.go
@@ -2,6 +2,7 @@ package stub
 
 import (
 	"github.com/openshift/api/samples/v1"
+
 	"github.com/openshift/cluster-samples-operator/pkg/util"
 )
 

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -14,37 +14,33 @@ import (
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	corev1lister "k8s.io/client-go/listers/core/v1"
-
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kapis "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
-
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1lister "k8s.io/client-go/listers/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 
 	imagev1 "github.com/openshift/api/image/v1"
+	operatorsv1api "github.com/openshift/api/operator/v1"
+	v1 "github.com/openshift/api/samples/v1"
 	templatev1 "github.com/openshift/api/template/v1"
-
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	imagev1lister "github.com/openshift/client-go/image/listers/image/v1"
+	sampleclientv1 "github.com/openshift/client-go/samples/clientset/versioned/typed/samples/v1"
 	configv1lister "github.com/openshift/client-go/samples/listers/samples/v1"
 	templatev1client "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
 	templatev1lister "github.com/openshift/client-go/template/listers/template/v1"
 
-	operatorsv1api "github.com/openshift/api/operator/v1"
-	v1 "github.com/openshift/api/samples/v1"
 	"github.com/openshift/cluster-samples-operator/pkg/cache"
 	sampopclient "github.com/openshift/cluster-samples-operator/pkg/client"
 	"github.com/openshift/cluster-samples-operator/pkg/metrics"
 	operatorstatus "github.com/openshift/cluster-samples-operator/pkg/operatorstatus"
 	"github.com/openshift/cluster-samples-operator/pkg/util"
-
-	sampleclientv1 "github.com/openshift/client-go/samples/clientset/versioned/typed/samples/v1"
 )
 
 const (

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -9,11 +9,6 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/openshift/api/samples/v1"
-	"github.com/openshift/cluster-samples-operator/pkg/cache"
-	operator "github.com/openshift/cluster-samples-operator/pkg/operatorstatus"
-	"github.com/openshift/cluster-samples-operator/pkg/util"
-
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,9 +19,13 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	operatorsv1api "github.com/openshift/api/operator/v1"
+	v1 "github.com/openshift/api/samples/v1"
 	templatev1 "github.com/openshift/api/template/v1"
-
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+
+	"github.com/openshift/cluster-samples-operator/pkg/cache"
+	operator "github.com/openshift/cluster-samples-operator/pkg/operatorstatus"
+	"github.com/openshift/cluster-samples-operator/pkg/util"
 )
 
 const (

--- a/pkg/stub/imagestreams.go
+++ b/pkg/stub/imagestreams.go
@@ -6,14 +6,17 @@ import (
 	"strings"
 	"time"
 
-	imagev1 "github.com/openshift/api/image/v1"
-	v1 "github.com/openshift/api/samples/v1"
-	"github.com/openshift/cluster-samples-operator/pkg/cache"
-	"github.com/openshift/cluster-samples-operator/pkg/util"
 	"github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kapis "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	v1 "github.com/openshift/api/samples/v1"
+
+	"github.com/openshift/cluster-samples-operator/pkg/cache"
+	"github.com/openshift/cluster-samples-operator/pkg/util"
 )
 
 func (h *Handler) processImageStreamWatchEvent(is *imagev1.ImageStream, deleted bool) error {

--- a/pkg/stub/interfaces.go
+++ b/pkg/stub/interfaces.go
@@ -7,6 +7,13 @@ import (
 	"os"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 
 	imagev1 "github.com/openshift/api/image/v1"
@@ -18,12 +25,6 @@ import (
 	sampleclientv1 "github.com/openshift/client-go/samples/clientset/versioned/typed/samples/v1"
 	configv1lister "github.com/openshift/client-go/samples/listers/samples/v1"
 	templatev1lister "github.com/openshift/client-go/template/listers/template/v1"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	restclient "k8s.io/client-go/rest"
 )
 
 type ImageStreamClientWrapper interface {

--- a/pkg/stub/jenkins.go
+++ b/pkg/stub/jenkins.go
@@ -3,8 +3,9 @@ package stub
 import (
 	"os"
 
-	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/sirupsen/logrus"
+
+	imagev1 "github.com/openshift/api/image/v1"
 )
 
 func tagInPayload(tag, env string, stream *imagev1.ImageStream) *imagev1.ImageStream {

--- a/pkg/stub/retry.go
+++ b/pkg/stub/retry.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	imagev1 "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
 	kapis "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	imagev1 "github.com/openshift/api/image/v1"
 )
 
 // The importTag related functions are for our import image retry and are

--- a/pkg/stub/templates.go
+++ b/pkg/stub/templates.go
@@ -1,11 +1,13 @@
 package stub
 
 import (
-	templatev1 "github.com/openshift/api/template/v1"
-	v1 "github.com/openshift/api/samples/v1"
 	"github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+
+	v1 "github.com/openshift/api/samples/v1"
+	templatev1 "github.com/openshift/api/template/v1"
 )
 
 func (h *Handler) processTemplateWatchEvent(t *templatev1.Template, deleted bool) error {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	samplev1 "github.com/openshift/api/samples/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8snet "k8s.io/apimachinery/pkg/util/net"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	samplev1 "github.com/openshift/api/samples/v1"
 )
 
 var (

--- a/test/e2e/cluster_samples_operator_test.go
+++ b/test/e2e/cluster_samples_operator_test.go
@@ -11,14 +11,14 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/client-go/util/retry"
-
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kapis "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	kubeset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 
 	configv1 "github.com/openshift/api/config/v1"
 	imageapiv1 "github.com/openshift/api/image/v1"
@@ -29,11 +29,11 @@ import (
 	imageset "github.com/openshift/client-go/image/clientset/versioned"
 	sampleclientv1 "github.com/openshift/client-go/samples/clientset/versioned"
 	templateset "github.com/openshift/client-go/template/clientset/versioned"
+
 	sampopclient "github.com/openshift/cluster-samples-operator/pkg/client"
 	operator "github.com/openshift/cluster-samples-operator/pkg/operatorstatus"
 	"github.com/openshift/cluster-samples-operator/pkg/stub"
 	"github.com/openshift/cluster-samples-operator/pkg/util"
-	kubeset "k8s.io/client-go/kubernetes"
 )
 
 var (

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -21,13 +21,15 @@ import (
 	"testing"
 	"time"
 
-	samplesapi "github.com/openshift/api/samples/v1"
-	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	sampopclient "github.com/openshift/cluster-samples-operator/pkg/client"
-	"github.com/openshift/cluster-samples-operator/test/framework"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeset "k8s.io/client-go/kubernetes"
+
+	samplesapi "github.com/openshift/api/samples/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	sampopclient "github.com/openshift/cluster-samples-operator/pkg/client"
+	"github.com/openshift/cluster-samples-operator/test/framework"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Sort and partition the existing go imports to align with
OpenShift organization standards.

No other changes were done except for the go imports reorganization.