### PR TITLE
[release-4.4] Bug 1842560: improve reason text on degraded condition

### DIFF
--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -887,6 +887,12 @@ func TestImageStreamCreateErrorDegradedReason(t *testing.T) {
 	mimic(&h, x86OCPContentRootDir)
 	fakeisclient := h.imageclientwrapper.(*fakeImageStreamClientWrapper)
 	fakeisclient.geterrors = map[string]error{"foo": err}
+
+	// fake out the fact the creds are there, so we can zero in
+	// on the API server error.
+	h.GoodConditionUpdate(cfg, corev1.ConditionTrue, v1.ImportCredentialsExist)
+	h.secretclientwrapper.(*fakeSecretClientWrapper).err = nil
+
 	h.Handle(event)
 	_, reason := util.AnyConditionUnknown(cfg)
 	if reason != "APIServerServiceUnavailableError" {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -61,13 +61,13 @@ func ConditionUnknown(s *samplev1.Config, c samplev1.ConfigConditionType) bool {
 	return false
 }
 
-func AnyConditionUnknown(s *samplev1.Config) bool {
+func AnyConditionUnknown(s *samplev1.Config) (bool, string) {
 	for _, rc := range s.Status.Conditions {
 		if rc.Status == corev1.ConditionUnknown {
-			return true
+			return true, rc.Reason
 		}
 	}
-	return false
+	return false, ""
 }
 
 func ConditionsMessages(s *samplev1.Config) string {
@@ -248,8 +248,8 @@ func ClusterOperatorStatusDegradedCondition(s *samplev1.Config) (configv1.Condit
 	// Conversely, those errors result in a ConditionUnknown setting on one
 	// of the conditions;
 	// If for some reason that ever changes, we'll need to adjust this
-	if AnyConditionUnknown(s) {
-		return trueRC, "APIServerError", ConditionsMessages(s)
+	if exists, reason := AnyConditionUnknown(s); exists {
+		return trueRC, reason, ConditionsMessages(s)
 	}
 	// return the initial state, don't set any messages.
 	return configv1.ConditionFalse, "", ""


### PR DESCRIPTION
replacement of automated cherry-pick of https://github.com/openshift/cluster-samples-operator/pull/275

see https://github.com/openshift/cluster-samples-operator/pull/281#issuecomment-636918855 for details on the need

reader's digest version:  install pull creds no longer needed in 4.5 but still are in 4.4