### PR TITLE
Fix samplesRegistry replacement in imageStreams when using paths

### DIFF
--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -1148,7 +1148,7 @@ func invalidConfig(t *testing.T, msg string, cfgValid *v1.ConfigCondition) {
 }
 
 func getISKeys() []string {
-	return []string{"foo", "bar"}
+	return []string{"foo", "bar", "baz"}
 }
 
 func getTKeys() []string {
@@ -1178,6 +1178,10 @@ func mimic(h *Handler, topdir string) {
 			},
 			{
 				name: "bar",
+				dir:  false,
+			},
+			{
+				name: "baz",
 				dir:  false,
 			},
 		},
@@ -1227,11 +1231,30 @@ func mimic(h *Handler, topdir string) {
 			},
 		},
 	}
+	baz := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "baz",
+			Labels: map[string]string{},
+		},
+		Spec: imagev1.ImageStreamSpec{
+			DockerImageRepository: registry2,
+			Tags: []imagev1.TagReference{
+				{
+					From: &corev1.ObjectReference{
+						Name: registry2 + "/repo/image:1.0",
+						Kind: "DockerImage",
+					},
+				},
+			},
+		},
+	}
 	fakeisgetter.streams = map[string]*imagev1.ImageStream{
 		topdir + "/imagestreams/foo": foo,
 		topdir + "/imagestreams/bar": bar,
+		topdir + "/imagestreams/baz": baz,
 		"foo":                        foo,
 		"bar":                        bar,
+		"baz":                        baz,
 	}
 	faketempgetter := h.Filetemplategetter.(*fakeTemplateFromFileGetter)
 	bo := &templatev1.Template{

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -481,6 +481,35 @@ func TestImageStreamEvent(t *testing.T) {
 		},
 	}
 	h.processImageStreamWatchEvent(is, false)
+	is = &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "baz",
+			Annotations: map[string]string{
+				v1.SamplesVersionAnnotation: h.version,
+			},
+		},
+		Spec: imagev1.ImageStreamSpec{
+			Tags: []imagev1.TagReference{
+				{
+					Name:       "baz",
+					Generation: &tagVersion,
+				},
+			},
+		},
+		Status: imagev1.ImageStreamStatus{
+			Tags: []imagev1.NamedTagEventList{
+				{
+					Tag: "baz",
+					Items: []imagev1.TagEvent{
+						{
+							Generation: tagVersion,
+						},
+					},
+				},
+			},
+		},
+	}
+	h.processImageStreamWatchEvent(is, false)
 	validate(true, err, "", cfg, conditions, statuses, t)
 }
 

--- a/pkg/stub/imagestreams.go
+++ b/pkg/stub/imagestreams.go
@@ -323,13 +323,13 @@ func (h *Handler) coreUpdateDockerPullSpec(oldreg, newreg string, oldies []strin
 			if strings.HasPrefix(oldreg, old) {
 				oldreg = strings.Replace(oldreg, old, newreg, 1)
 				logrus.Debugf("coreUpdatePull hasReg1 reg now %s", oldreg)
-			} else {
-				// the content from openshift/library has something odd in in ... replace the registry piece
-				parts := strings.Split(oldreg, "/")
-				oldreg = newreg + "/" + parts[1] + "/" + parts[2]
-				logrus.Debugf("coreUpdatePull hasReg2 reg now %s", oldreg)
+				return oldreg
 			}
 		}
+		// the content from openshift/library has something odd in in ... replace the registry piece
+		parts := strings.Split(oldreg, "/")
+		oldreg = newreg + "/" + parts[1] + "/" + parts[2]
+		logrus.Debugf("coreUpdatePull hasReg2 reg now %s", oldreg)
 	} else {
 		oldreg = newreg + "/" + oldreg
 		logrus.Debugf("coreUpdatePull no hasReg reg now %s", oldreg)


### PR DESCRIPTION
Currently, when defining samplesRegistry in the CR with a value of newhost:1111/path, the resulting imageStream DockerImage values become newhost:1111/path/path/path instead of newhost:1111/path/oldpaths.
This PR makes it possible to have a path in samplesRegistry in the CR. This could be beneficial when using external registries with paths (e.g. Artifactory remote registries).