### PR TITLE
[BUILD-92] add import retry count into metrics

### DIFF
--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -81,3 +81,7 @@ func TBRInaccessibleOnBoot(badTBR bool) {
 	}
 	tbrInaccessibleOnBootStat.Set(0)
 }
+
+func ImageStreamImportRetry() {
+	importRetryStat.Inc()
+}

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -13,6 +13,7 @@ import (
 	mr "math/rand"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,8 +21,12 @@ import (
 	"github.com/prometheus/common/expfmt"
 )
 
+var portMap = sync.Map{}
+
 func TestMain(m *testing.M) {
 	var err error
+
+	mr.Seed(time.Now().UnixNano())
 
 	tlsKey, tlsCRT, err = generateTempCertificates()
 	if err != nil {
@@ -39,9 +44,22 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func generatePort() int {
-	mr.Seed(time.Now().UnixNano())
-	return mr.Intn(4000) + 6000
+func generatePort(t *testing.T) int {
+	port := 0
+	for i := 0; i < 200; i++ {
+		port = mr.Intn(4000) + 6000
+		_, alreadyLoaded := portMap.LoadOrStore(port, port)
+		if alreadyLoaded {
+			t.Logf("port %v in use, trying again", port)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		break
+	}
+	if port == 0 {
+		t.Fatal("could not get unique metrics port")
+	}
+	return port
 }
 
 func generateTempCertificates() (string, string, error) {
@@ -84,7 +102,7 @@ func generateTempCertificates() (string, string, error) {
 func TestRun(t *testing.T) {
 	ch := make(chan struct{})
 	defer close(ch)
-	port := generatePort()
+	port := generatePort(t)
 	srv := BuildServer(port)
 	go RunServer(srv, ch)
 
@@ -98,81 +116,45 @@ func TestRun(t *testing.T) {
 	}
 }
 
-func TestBinaryMetrics(t *testing.T) {
+func runServer(t *testing.T) (chan struct{}, int) {
 	ch := make(chan struct{})
-	defer close(ch)
-	port := generatePort()
+	port := generatePort(t)
 	srv := BuildServer(port)
 	go RunServer(srv, ch)
-	for _, t1 := range []struct {
-		method func(bool)
-		query  string
-	}{
-		{
-			method: Degraded,
-			query:  degradedQuery,
-		},
-		{
-			method: ConfigInvalid,
-			query:  invalidConfigQuery,
-		},
-		{
-			method: TBRInaccessibleOnBoot,
-			query:  tbrInaccessibleOnBootstrapQuery,
-		},
-	} {
-		for _, tt := range []struct {
-			name string
-			iter int
-			val  bool
-			expt float64
-		}{
-			{
-				name: "single set to true",
-				iter: 1,
-				val:  true,
-				expt: 1,
-			},
-			{
-				name: "single set to false",
-				iter: 1,
-				val:  false,
-				expt: 0,
-			},
-			{
-				name: "multiple set to true",
-				iter: 2,
-				val:  true,
-				expt: 1,
-			},
-			{
-				name: "multiple set to false",
-				iter: 2,
-				val:  false,
-				expt: 0,
-			},
-		} {
-			t.Run(tt.name, func(t *testing.T) {
-				for i := 0; i < tt.iter; i++ {
-					t1.method(tt.val)
-				}
+	return ch, port
+}
 
-				resp, err := http.Get(fmt.Sprintf("https://localhost:%d/metrics", port))
-				if err != nil {
-					t.Fatalf("error requesting metrics server: %v", err)
-				}
+func testQueryGaugeMetric(t *testing.T, port, value int, query string) {
+	resp, err := http.Get(fmt.Sprintf("https://localhost:%d/metrics", port))
+	if err != nil {
+		t.Fatalf("error requesting metrics server: %v", err)
+	}
+	metrics := findMetricsByCounter(resp.Body, query)
+	if len(metrics) == 0 {
+		t.Fatalf("unable to locate metric %s", query)
+	}
+	if metrics[0].Gauge.Value == nil {
+		t.Fatalf("metric did not have value %s", query)
+	}
+	if *metrics[0].Gauge.Value != float64(value) {
+		t.Fatalf("incorrect metric value %v for query %s", *metrics[0].Gauge.Value, query)
+	}
+}
 
-				metrics := findMetricsByCounter(resp.Body, t1.query)
-				if len(metrics) == 0 {
-					t.Fatal("unable to locate metric", t1.query)
-				}
-
-				val := *metrics[0].Gauge.Value
-				if val != tt.expt {
-					t.Errorf("expected %.0f, found %.0f", tt.expt, val)
-				}
-			})
-		}
+func testQueryCounterMetric(t *testing.T, port, value int, query string) {
+	resp, err := http.Get(fmt.Sprintf("https://localhost:%d/metrics", port))
+	if err != nil {
+		t.Fatalf("error requesting metrics server: %v", err)
+	}
+	metrics := findMetricsByCounter(resp.Body, query)
+	if len(metrics) == 0 {
+		t.Fatalf("unable to locate metric %s", query)
+	}
+	if metrics[0].Counter.Value == nil {
+		t.Fatalf("metric did not have value %s", query)
+	}
+	if *metrics[0].Counter.Value != float64(value) {
+		t.Fatalf("incorrect metric value %v for query %s", *metrics[0].Counter.Value, query)
 	}
 }
 
@@ -186,4 +168,79 @@ func findMetricsByCounter(buf io.ReadCloser, name string) []*io_prometheus_clien
 		}
 	}
 	return nil
+}
+
+func TestDegradedOn(t *testing.T) {
+	ch, port := runServer(t)
+	defer close(ch)
+
+	Degraded(true)
+	testQueryGaugeMetric(t, port, 1, degradedQuery)
+	// makes sure it does not go greater than 1
+	Degraded(true)
+	testQueryGaugeMetric(t, port, 1, degradedQuery)
+}
+
+func TestDegradedOff(t *testing.T) {
+	ch, port := runServer(t)
+	defer close(ch)
+
+	Degraded(false)
+	testQueryGaugeMetric(t, port, 0, degradedQuery)
+	// makes sure it does not go less than 0
+	Degraded(false)
+	testQueryGaugeMetric(t, port, 0, degradedQuery)
+}
+
+func TestConfigInvalidOn(t *testing.T) {
+	ch, port := runServer(t)
+	defer close(ch)
+
+	ConfigInvalid(true)
+	testQueryGaugeMetric(t, port, 1, invalidConfigQuery)
+	// makes sure it does not go greater than 1
+	ConfigInvalid(true)
+	testQueryGaugeMetric(t, port, 1, invalidConfigQuery)
+}
+
+func TestConfigInvalidOff(t *testing.T) {
+	ch, port := runServer(t)
+	defer close(ch)
+
+	ConfigInvalid(false)
+	testQueryGaugeMetric(t, port, 0, invalidConfigQuery)
+	// makes sure it does not go less than 0
+	ConfigInvalid(false)
+	testQueryGaugeMetric(t, port, 0, invalidConfigQuery)
+}
+
+func TestTBRInaccessibleOnBootOn(t *testing.T) {
+	ch, port := runServer(t)
+	defer close(ch)
+
+	TBRInaccessibleOnBoot(true)
+	testQueryGaugeMetric(t, port, 1, tbrInaccessibleOnBootstrapQuery)
+	// makes sure it does not go greater than 1
+	TBRInaccessibleOnBoot(true)
+	testQueryGaugeMetric(t, port, 1, tbrInaccessibleOnBootstrapQuery)
+}
+
+func TestTBRInaccessibleOnBootOff(t *testing.T) {
+	ch, port := runServer(t)
+	defer close(ch)
+
+	TBRInaccessibleOnBoot(false)
+	testQueryGaugeMetric(t, port, 0, tbrInaccessibleOnBootstrapQuery)
+	// makes sure it does not go less than 0
+	TBRInaccessibleOnBoot(false)
+	testQueryGaugeMetric(t, port, 0, tbrInaccessibleOnBootstrapQuery)
+}
+
+func TestImageStreamImportRetry(t *testing.T) {
+	ch, port := runServer(t)
+	defer close(ch)
+	for i := 1; i < 3; i++ {
+		ImageStreamImportRetry()
+		testQueryCounterMetric(t, port, i, importRetryQuery)
+	}
 }

--- a/pkg/stub/imagestreams.go
+++ b/pkg/stub/imagestreams.go
@@ -16,6 +16,7 @@ import (
 	v1 "github.com/openshift/api/samples/v1"
 
 	"github.com/openshift/cluster-samples-operator/pkg/cache"
+	"github.com/openshift/cluster-samples-operator/pkg/metrics"
 	"github.com/openshift/cluster-samples-operator/pkg/util"
 )
 
@@ -467,6 +468,7 @@ func (h *Handler) processImportStatus(is *imagev1.ImageStream, cfg *v1.Config) (
 							logrus.Warningf("attempted to initiate an imagestreamimport retry for imagestream/tag %s/%s but got err %v; simply moving on", is.Name, statusTag.Tag, err)
 							break
 						}
+						metrics.ImageStreamImportRetry()
 						logrus.Printf("initiated an imagestreamimport retry for imagestream/tag %s/%s", is.Name, statusTag.Tag)
 
 					}


### PR DESCRIPTION
motivated by the debuggability initiative started reviewing things for samples

we actually have a lot already there when you look at 
- invalid config indications in operator, metrics
- other metrics
-- which imagestreams have failed imports
-- are tbr creds missing from the install pull secret
-- was the tbr inaccessible on initial install
- must gather data
-- openshift imagestream yaml grabbed
-- pod logs, config/operator grabbed
- reason/message usage when degraded/progressing
-- different reasons around failed import vs. api server error (with specific error in reason) vs. file system error 
-- imagestream error snipptes in message
-- last retry time in message

but a more explicit indication that we are retrying failed imports as expected on our periodic basis, vs. just confirming in the pod logs could help

so this PR adds a metric around that 

@adambkaplan @coreydaley @otaviof 

https://issues.redhat.com/browse/BUILD-92