### PR TITLE
Bug 1854857: initial create errors should map to SamplesExists instead of ImageChangesInProgress

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -877,8 +877,8 @@ func (h *Handler) Handle(event util.Event) error {
 
 			if err != nil {
 				cfg = h.refetchCfgMinimizeConflicts(cfg)
-				h.processError(cfg, v1.ImageChangesInProgress, corev1.ConditionUnknown, err, "error creating samples: %v")
-				dbg := "setting in progress to unknown"
+				h.processError(cfg, v1.SamplesExist, corev1.ConditionUnknown, err, "error creating samples: %v")
+				dbg := "setting samples exists to unknown"
 				logrus.Printf("CRDUPDATE %s", dbg)
 				e := h.crdwrapper.UpdateStatus(cfg, dbg)
 				if e != nil {

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -832,12 +832,30 @@ func TestImageGetError(t *testing.T) {
 		statuses := []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse}
 		err := h.Handle(event)
 		if !kerrors.IsNotFound(iserr) {
-			statuses[3] = corev1.ConditionUnknown
+			statuses[0] = corev1.ConditionUnknown
+			statuses[3] = corev1.ConditionFalse
 			validate(false, err, "getstreamerror", cfg, conditions, statuses, t)
 		} else {
 			validate(true, err, "", cfg, conditions, statuses, t)
 		}
 	}
+
+}
+
+func TestImageUpdateError(t *testing.T) {
+
+	h, cfg, event := setup()
+
+	mimic(&h, x86OCPContentRootDir)
+
+	fakeisclient := h.imageclientwrapper.(*fakeImageStreamClientWrapper)
+	fakeisclient.upserterrors = map[string]error{"foo": kerrors.NewServiceUnavailable("upsertstreamerror")}
+
+	statuses := []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse}
+	err := h.Handle(event)
+	statuses[0] = corev1.ConditionUnknown
+	statuses[3] = corev1.ConditionFalse
+	validate(false, err, "upsertstreamerror", cfg, conditions, statuses, t)
 
 }
 
@@ -1142,7 +1160,7 @@ func TestImageImportRequestCreation(t *testing.T) {
 	}
 }
 
-func TestTemplateGetEreror(t *testing.T) {
+func TestTemplateGetError(t *testing.T) {
 	errors := []error{
 		fmt.Errorf("gettemplateerror"),
 		kerrors.NewNotFound(schema.GroupResource{}, "gettemplateerror"),
@@ -1158,13 +1176,29 @@ func TestTemplateGetEreror(t *testing.T) {
 		statuses := []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse}
 		err := h.Handle(event)
 		if !kerrors.IsNotFound(terr) {
-			statuses[3] = corev1.ConditionUnknown
+			statuses[0] = corev1.ConditionUnknown
+			statuses[3] = corev1.ConditionFalse
 			validate(false, err, "gettemplateerror", cfg, conditions, statuses, t)
 		} else {
 			validate(true, err, "", cfg, conditions, statuses, t)
 		}
 	}
 
+}
+
+func TestTemplateUpsertError(t *testing.T) {
+	h, cfg, event := setup()
+
+	mimic(&h, x86OCPContentRootDir)
+
+	faketclient := h.templateclientwrapper.(*fakeTemplateClientWrapper)
+	faketclient.upserterrors = map[string]error{"bo": kerrors.NewServiceUnavailable("upsertstreamerror")}
+
+	statuses := []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse}
+	err := h.Handle(event)
+	statuses[0] = corev1.ConditionUnknown
+	statuses[3] = corev1.ConditionFalse
+	validate(false, err, "upsertstreamerror", cfg, conditions, statuses, t)
 }
 
 func TestDeletedCR(t *testing.T) {


### PR DESCRIPTION
So we finally got an intermittent situation when the api server was momentarily unavailable during an upgrade when samples operator tried to upsert new samples.

In setting the error condition, the code (since 4.1 I believe) set the error on the ImageChangesInProgress condition.

However, that results in text in the reason field which would not get cleared as we start tracking import completion in the ImageChangesInProgress reason field.  As it never gets cleared, we never set Progressing to false.

The pattern in samples operator is to set these errors in SamplesExists, as that reflects whether samples are fully created/up to date.

This PR hence fixes this single inconsistency.  I went back and confirmed this was the only place this situation was occurring.
Also added some additional unit tests to distinguish between api server get errors and upsert errors.