### PR TITLE
OKD: add mysql 5.7 imagestream

### DIFF
--- a/assets/operator/okd-x86_64/mysql/imagestreams/mysql-centos7.json
+++ b/assets/operator/okd-x86_64/mysql/imagestreams/mysql-centos7.json
@@ -51,6 +51,26 @@
 				"referencePolicy": {
 					"type": "Local"
 				}
+			},
+			{
+				"name": "5.7",
+				"annotations": {
+					"description": "Provides a MySQL 5.7 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
+					"iconClass": "icon-mysql-database",
+					"openshift.io/display-name": "MySQL 5.7",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "mysql",
+					"version": "5.7"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "docker.io/centos/mysql-57-centos7:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
 			}
 		]
 	},


### PR DESCRIPTION

CakePHP template still requires MySQL 5.7