### PR TITLE
[release-4.4] Bug 1871832: initial create errors should map to SamplesExists instead of ImageChangesInProgress

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -933,8 +933,8 @@ func (h *Handler) Handle(event util.Event) error {
 
 			if err != nil {
 				cfg = h.refetchCfgMinimizeConflicts(cfg)
-				h.processError(cfg, v1.ImageChangesInProgress, corev1.ConditionUnknown, err, "error creating samples: %v")
-				dbg := "setting in progress to unknown"
+				h.processError(cfg, v1.SamplesExist, corev1.ConditionUnknown, err, "error creating samples: %v")
+				dbg := "setting samples exists to unknown"
 				logrus.Printf("CRDUPDATE %s", dbg)
 				e := h.crdwrapper.UpdateStatus(cfg, dbg)
 				if e != nil {

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -918,12 +918,34 @@ func TestImageGetError(t *testing.T) {
 		statuses := []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse}
 		err := h.Handle(event)
 		if !kerrors.IsNotFound(iserr) {
-			statuses[3] = corev1.ConditionUnknown
+			statuses[0] = corev1.ConditionUnknown
+			statuses[3] = corev1.ConditionFalse
 			validate(false, err, "getstreamerror", cfg, conditions, statuses, t)
 		} else {
 			validate(true, err, "", cfg, conditions, statuses, t)
 		}
 	}
+
+}
+
+func TestImageUpdateError(t *testing.T) {
+
+	h, cfg, event := setup()
+
+	mimic(&h, x86OCPContentRootDir)
+
+	// process credentials so that check does not short circuit our attempt to validate the template upsert
+	// error logic
+	processCred(&h, cfg, t)
+
+	fakeisclient := h.imageclientwrapper.(*fakeImageStreamClientWrapper)
+	fakeisclient.upserterrors = map[string]error{"foo": kerrors.NewServiceUnavailable("upsertstreamerror")}
+
+	statuses := []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse}
+	err := h.Handle(event)
+	statuses[0] = corev1.ConditionUnknown
+	statuses[3] = corev1.ConditionFalse
+	validate(false, err, "upsertstreamerror", cfg, conditions, statuses, t)
 
 }
 
@@ -1228,7 +1250,7 @@ func TestImageImportRequestCreation(t *testing.T) {
 	}
 }
 
-func TestTemplateGetEreror(t *testing.T) {
+func TestTemplateGetError(t *testing.T) {
 	errors := []error{
 		fmt.Errorf("gettemplateerror"),
 		kerrors.NewNotFound(schema.GroupResource{}, "gettemplateerror"),
@@ -1245,13 +1267,33 @@ func TestTemplateGetEreror(t *testing.T) {
 		statuses := []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse}
 		err := h.Handle(event)
 		if !kerrors.IsNotFound(terr) {
-			statuses[3] = corev1.ConditionUnknown
+			statuses[0] = corev1.ConditionUnknown
+			statuses[3] = corev1.ConditionFalse
 			validate(false, err, "gettemplateerror", cfg, conditions, statuses, t)
 		} else {
 			validate(true, err, "", cfg, conditions, statuses, t)
 		}
 	}
 
+}
+
+func TestTemplateUpsertError(t *testing.T) {
+	h, cfg, event := setup()
+
+	mimic(&h, x86OCPContentRootDir)
+
+	// process credentials so that check does not short circuit our attempt to validate the template upsert
+	// error logic
+	processCred(&h, cfg, t)
+
+	faketclient := h.templateclientwrapper.(*fakeTemplateClientWrapper)
+	faketclient.upserterrors = map[string]error{"bo": kerrors.NewServiceUnavailable("upsertstreamerror")}
+
+	statuses := []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse}
+	err := h.Handle(event)
+	statuses[0] = corev1.ConditionUnknown
+	statuses[3] = corev1.ConditionFalse
+	validate(false, err, "upsertstreamerror", cfg, conditions, statuses, t)
 }
 
 func TestDeletedCR(t *testing.T) {


### PR DESCRIPTION
This PR is needed to replace #314 from the cherrypick bot because of differences in behavior between 4.4 and 4.5/4.6

We copy creds and track that condition in 4.4, but no longer do so in 4.5/4.6, so the unit tests in 4.4 need an additional step of adding the necessary security conditions via a call to `processCred` to bypass that short circuit so we can get to validating the template / imagestream upsert error logic.

See detailed triage in https://github.com/openshift/cluster-samples-operator/pull/314#issuecomment-679110733

