### PR TITLE
Bug 1872080: add new okd e2e to validate okd vs. ocp content is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ test-unit:
 test-e2e:
 	KUBERNETES_CONFIG=${KUBECONFIG} go test -parallel 1 -timeout 30m -v ./test/e2e/...
 
+test-e2e-okd:
+	OKD=yes KUBERNETES_CONFIG=${KUBECONFIG} go test -parallel 1 -timeout 30m -v ./test/e2e/...
+
 clean:
 	rm -f cluster-samples-operator
 	rm -rf _output/

--- a/test/e2e/cluster_samples_operator_test.go
+++ b/test/e2e/cluster_samples_operator_test.go
@@ -317,8 +317,13 @@ func getContentDir(t *testing.T) string {
 		startDir = filepath.Dir(startDir)
 	}
 	contentDir := ""
+	suffix := "ocp-x86_64"
+	_, present := os.LookupEnv("OKD")
+	if present {
+		suffix = "okd-x86_64"
+	}
 	_ = filepath.Walk(startDir, func(path string, info os.FileInfo, err error) error {
-		if strings.HasSuffix(strings.TrimSpace(path), "ocp-x86_64") {
+		if strings.HasSuffix(strings.TrimSpace(path), suffix) {
 			contentDir = path
 			return fmt.Errorf("found contentDir %s", contentDir)
 		}


### PR DESCRIPTION
A force merge or test override is likely needed since the okd-e2e-aws-operator job in openshift/release needs to validate against the new `make test-e2e-okd`

@vrutkovs @yselkowitz FYI

aside from the rehearsals in my https://github.com/openshift/release/pull/11340, we'll validate against @yselkowitz 's https://github.com/openshift/cluster-samples-operator/pull/317 and the updated UBI8 based OKD content