### PR TITLE
BUILD-145: store imagestreamtag to image mappings in configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ The samples resource maintains the following conditions in its status:
 See https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#conditions for how these
 Cluster Operator status conditions are managed.
 
+# Disconnected mirroring assistance
+
+A `ConfigMap` named `imagestreamtag-to-image` is created in the Samples Operator's namespace that contains an
+entry for each `ImageStreamTag`, where the value of the entry is the image used to populate that `ImageStreamTag`.
+
+The format of the key for each entry in the `data` field in the `ConfigMap` is `<imagestreamname>_<imagestreamtagname>`.
+
+Samples Operator will come up as `Removed` for a disconnected OCP install.  If you choose to change it to `Managed`,
+override the registry to a mirror registry available in your disconnected environment, you can use this `ConfigMap`
+as a reference for which images need to be mirrored for your `ImageStreams` of interest to properly import.
 
 # Troubleshooting
 

--- a/manifests/010-prometheus-rules.yaml
+++ b/manifests/010-prometheus-rules.yaml
@@ -83,3 +83,9 @@ spec:
       annotations:
         message: |
           Samples operator could not access 'registry.redhat.io' during its initial installation and it boostrapped as removed.
+          If this is expected, and stems from installing in a restricted network environment, please note that if you
+          plan on mirroring images associated with sample imagestreams into a registry available in your restricted
+          network environment, and subsequently moving samples operator back to 'Managed' state, a list of the images
+          associated with each image stream tag from the samples catalog is
+          provided in the 'imagestreamtag-to-image' config map in the 'openshift-cluster-samples-operator' namespace to
+          assist the mirroring process.

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -13,4 +13,5 @@ type Listers struct {
 	ImageStreams           imagelisters.ImageStreamNamespaceLister
 	Templates              templatelisters.TemplateNamespaceLister
 	Config                 sampoplisters.ConfigLister
+	ConfigMaps             corelisters.ConfigMapNamespaceLister
 }

--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -23,7 +23,7 @@ import (
 const (
 	ClusterOperatorName = "openshift-samples"
 	doingDelete         = "DeletionInProgress"
-	unsuppArch              = "UnsupportHWArchitecture"
+	unsuppArch          = "UnsupportHWArchitecture"
 	ipv6                = "IPv6Platform"
 	TBR                 = "TermsBasedRegistryUnreacahable"
 )

--- a/pkg/stub/files.go
+++ b/pkg/stub/files.go
@@ -38,6 +38,14 @@ func (h *Handler) processFiles(dir string, files []os.FileInfo, opcfg *v1.Config
 			}
 			h.imagestreamFile[imagestream.Name] = path
 			metrics.AddStream(imagestream.Name)
+			if !strings.HasPrefix(imagestream.Name, "jenkins") {
+				for _, tag := range imagestream.Spec.Tags {
+					if tag.From.Kind != "DockerImage" {
+						continue
+					}
+					h.imagestreatagToImage[imagestream.Name+"_"+tag.Name] = tag.From.Name
+				}
+			}
 			continue
 		}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -152,6 +152,7 @@ const (
 	// numConfigConditionType is a helper constant that captures the number possible conditions
 	// defined above in this const block
 	numconfigConditionType = 7
+	IST2ImageMap           = "imagestreamtag-to-image"
 )
 
 // ClusterOperatorStatusAvailableCondition return values are as follows:

--- a/test/e2e/cluster_samples_operator_test.go
+++ b/test/e2e/cluster_samples_operator_test.go
@@ -134,6 +134,18 @@ func verifyOperatorUp(t *testing.T) *samplesapi.Config {
 	if err != nil {
 		t.Fatalf("error waiting for samples resource to appear: %v", err)
 	}
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		_, err = kubeClient.CoreV1().ConfigMaps(samplesapi.OperatorNamespace).Get(
+			context.TODO(), util.IST2ImageMap, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("%s", err.Error())
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("error waiting for ist to image map: %s", err.Error())
+	}
 	return cfg
 }
 


### PR DESCRIPTION
@bparees @sbose78 @adambkaplan @coreydaley @otaviof @bmcelvee 

this PR introduces a configmap into the samples operator namespace that has imagestreamtag to image mappings for the samples inventory ... basically I liked @bparees 's idea better than mine in slack :-)

it stems from the exchange in openshift-sme around trying to use the existing documentation's use of `oc` on a "connected" cluster to get the list of images to mirror in a disconnected cluster

this configmap will get created even in a disconnected cluster that bootstraps as removed

if we deliver this, we'd want to update the OCP docs to replace the current directions for obtaining image refs with directions on utilizing this new config map

Also, some seed planting @bparees @sbose78 @adambkaplan with 4.7 planning coming up:
- I could see this change, even more so than https://github.com/openshift/cluster-samples-operator/pull/313 (though I think both qualify) as changes that would improve customer experience and help reduce customer cases wrt samples
- If so, as I mentioned to @adambkaplan during scrum, assuming this gets approved for 4.7, and as part of this 4.7 initiative in general, what are the org's thoughts around backporting stuff like this to released versions of OCP to further assist in customer experience, etc.

Lastly, a snapshot of the contents of the configmap:

```
  data:
    apicast-gateway_2.1.0.GA: registry.redhat.io/3scale-amp21/apicast-gateway:1.4-2
    apicast-gateway_2.2.0.GA: registry.redhat.io/3scale-amp22/apicast-gateway:1.8
    apicast-gateway_2.3.0.GA: registry.redhat.io/3scale-amp23/apicast-gateway
    apicast-gateway_2.4.0.GA: registry.redhat.io/3scale-amp24/apicast-gateway
    apicast-gateway_2.5.0.GA: registry.redhat.io/3scale-amp25/apicast-gateway
    apicast-gateway_2.6.0.GA: registry.redhat.io/3scale-amp26/apicast-gateway
    apicast-gateway_2.7.0.GA: registry.redhat.io/3scale-amp2/apicast-gateway-rhel7:3scale2.7
    apicast-gateway_2.8.0.GA: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.8
    apicast-gateway_2.9.0.GA: registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.9
    apicurito-ui_1.2: registry.redhat.io/fuse7/fuse-apicurito:1.2
    apicurito-ui_1.3: registry.redhat.io/fuse7/fuse-apicurito:1.3
    apicurito-ui_1.4: registry.redhat.io/fuse7/fuse-apicurito:1.4
    apicurito-ui_1.5: registry.redhat.io/fuse7/fuse-apicurito:1.5
    apicurito-ui_1.6: registry.redhat.io/fuse7/fuse-apicurito:1.6
    dotnet-runtime_2.1: registry.redhat.io/dotnet/dotnet-21-runtime-rhel7:2.1
    dotnet-runtime_3.1: registry.redhat.io/dotnet/dotnet-31-runtime-rhel7:3.1
    dotnet_2.1: registry.redhat.io/dotnet/dotnet-21-rhel7:2.1
    dotnet_3.1: registry.redhat.io/dotnet/dotnet-31-rhel7:3.1
    eap-cd-openshift_12.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift:12.0
    eap-cd-openshift_13.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift:13.0
    eap-cd-openshift_14.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift:14.0
    eap-cd-openshift_15.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift:15.0
    eap-cd-openshift_16.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift:16.0
    eap-cd-openshift_17.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:17.0
    eap-cd-openshift_18.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:18.0
    eap-cd-openshift_19.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:19.0
    eap-cd-openshift_20.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:20.0
    eap-cd-openshift_latest: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:latest
    eap-cd-runtime-openshift_18.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-runtime-openshift-rhel8:18.0
    eap-cd-runtime-openshift_19.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-runtime-openshift-rhel8:19.0
    eap-cd-runtime-openshift_20.0: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-runtime-openshift-rhel8:20.0
    eap-cd-runtime-openshift_latest: registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-runtime-openshift-rhel8:latest
    fis-java-openshift_1.0: registry.redhat.io/jboss-fuse-6/fis-java-openshift:1.0
    fis-java-openshift_2.0: registry.redhat.io/jboss-fuse-6/fis-java-openshift:2.0
    fis-karaf-openshift_1.0: registry.redhat.io/jboss-fuse-6/fis-karaf-openshift:1.0
    fis-karaf-openshift_2.0: registry.redhat.io/jboss-fuse-6/fis-karaf-openshift:2.0
    fuse-apicurito-generator_1.2: registry.redhat.io/fuse7/fuse-apicurito-generator:1.2
    fuse-apicurito-generator_1.3: registry.redhat.io/fuse7/fuse-apicurito-generator:1.3
    fuse-apicurito-generator_1.4: registry.redhat.io/fuse7/fuse-apicurito-generator:1.4
    fuse-apicurito-generator_1.5: registry.redhat.io/fuse7/fuse-apicurito-generator:1.5
    fuse-apicurito-generator_1.6: registry.redhat.io/fuse7/fuse-apicurito-generator:1.6
    fuse7-console_1.0: registry.redhat.io/fuse7/fuse-console:1.0
    fuse7-console_1.1: registry.redhat.io/fuse7/fuse-console:1.1
    fuse7-console_1.2: registry.redhat.io/fuse7/fuse-console:1.2
    fuse7-console_1.3: registry.redhat.io/fuse7/fuse-console:1.3
    fuse7-console_1.4: registry.redhat.io/fuse7/fuse-console:1.4
    fuse7-console_1.5: registry.redhat.io/fuse7/fuse-console:1.5
    fuse7-console_1.6: registry.redhat.io/fuse7/fuse-console:1.6
    fuse7-eap-openshift_1.0: registry.redhat.io/fuse7/fuse-eap-openshift:1.0
    fuse7-eap-openshift_1.1: registry.redhat.io/fuse7/fuse-eap-openshift:1.1
    fuse7-eap-openshift_1.2: registry.redhat.io/fuse7/fuse-eap-openshift:1.2
    fuse7-eap-openshift_1.3: registry.redhat.io/fuse7/fuse-eap-openshift:1.3
    fuse7-eap-openshift_1.4: registry.redhat.io/fuse7/fuse-eap-openshift:1.4
    fuse7-eap-openshift_1.5: registry.redhat.io/fuse7/fuse-eap-openshift:1.5
    fuse7-eap-openshift_1.6: registry.redhat.io/fuse7/fuse-eap-openshift:1.6
    fuse7-java-openshift_1.0: registry.redhat.io/fuse7/fuse-java-openshift:1.0
    fuse7-java-openshift_1.1: registry.redhat.io/fuse7/fuse-java-openshift:1.1
    fuse7-java-openshift_1.2: registry.redhat.io/fuse7/fuse-java-openshift:1.2
    fuse7-java-openshift_1.3: registry.redhat.io/fuse7/fuse-java-openshift:1.3
    fuse7-java-openshift_1.4: registry.redhat.io/fuse7/fuse-java-openshift:1.4
    fuse7-java-openshift_1.5: registry.redhat.io/fuse7/fuse-java-openshift:1.5
    fuse7-java-openshift_1.6: registry.redhat.io/fuse7/fuse-java-openshift:1.6
    fuse7-karaf-openshift_1.0: registry.redhat.io/fuse7/fuse-karaf-openshift:1.0
    fuse7-karaf-openshift_1.1: registry.redhat.io/fuse7/fuse-karaf-openshift:1.1
    fuse7-karaf-openshift_1.2: registry.redhat.io/fuse7/fuse-karaf-openshift:1.2
    fuse7-karaf-openshift_1.3: registry.redhat.io/fuse7/fuse-karaf-openshift:1.3
    fuse7-karaf-openshift_1.4: registry.redhat.io/fuse7/fuse-karaf-openshift:1.4
    fuse7-karaf-openshift_1.5: registry.redhat.io/fuse7/fuse-karaf-openshift:1.5
    fuse7-karaf-openshift_1.6: registry.redhat.io/fuse7/fuse-karaf-openshift:1.6
    golang_1.13.4-ubi7: registry.redhat.io/ubi7/go-toolset:1.13.4
    golang_1.13.4-ubi8: registry.redhat.io/ubi8/go-toolset:1.13.4
    httpd_2.4: registry.redhat.io/rhscl/httpd-24-rhel7
    httpd_2.4-el7: registry.redhat.io/rhscl/httpd-24-rhel7
    httpd_2.4-el8: registry.redhat.io/rhel8/httpd-24
    java_8: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest
    java_11: registry.redhat.io/openjdk/openjdk-11-rhel7:latest
    jboss-amq-62_1.1: registry.redhat.io/jboss-amq-6/amq62-openshift:1.1
    jboss-amq-62_1.2: registry.redhat.io/jboss-amq-6/amq62-openshift:1.2
    jboss-amq-62_1.3: registry.redhat.io/jboss-amq-6/amq62-openshift:1.3
    jboss-amq-62_1.4: registry.redhat.io/jboss-amq-6/amq62-openshift:1.4
    jboss-amq-62_1.5: registry.redhat.io/jboss-amq-6/amq62-openshift:1.5
    jboss-amq-62_1.6: registry.redhat.io/jboss-amq-6/amq62-openshift:1.6
    jboss-amq-62_1.7: registry.redhat.io/jboss-amq-6/amq62-openshift:1.7
    jboss-amq-63_1.0: registry.redhat.io/jboss-amq-6/amq63-openshift:1.0
    jboss-amq-63_1.1: registry.redhat.io/jboss-amq-6/amq63-openshift:1.1
    jboss-amq-63_1.2: registry.redhat.io/jboss-amq-6/amq63-openshift:1.2
    jboss-amq-63_1.3: registry.redhat.io/jboss-amq-6/amq63-openshift:1.3
    jboss-amq-63_1.4: registry.redhat.io/jboss-amq-6/amq63-openshift:1.4
    jboss-datagrid65-client-openshift_1.0: registry.redhat.io/jboss-datagrid-6/datagrid65-client-openshift:1.0
    jboss-datagrid65-client-openshift_1.1: registry.redhat.io/jboss-datagrid-6/datagrid65-client-openshift:1.1
    jboss-datagrid65-openshift_1.2: registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.2
    jboss-datagrid65-openshift_1.3: registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.3
    jboss-datagrid65-openshift_1.4: registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.4
    jboss-datagrid65-openshift_1.5: registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.5
    jboss-datagrid65-openshift_1.6: registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.6
    jboss-datagrid71-client-openshift_1.0: registry.redhat.io/jboss-datagrid-7/datagrid71-client-openshift:1.0
    jboss-datagrid71-openshift_1.0: registry.redhat.io/jboss-datagrid-7/datagrid71-openshift:1.0
    jboss-datagrid71-openshift_1.1: registry.redhat.io/jboss-datagrid-7/datagrid71-openshift:1.1
    jboss-datagrid71-openshift_1.2: registry.redhat.io/jboss-datagrid-7/datagrid71-openshift:1.2
    jboss-datagrid71-openshift_1.3: registry.redhat.io/jboss-datagrid-7/datagrid71-openshift:1.3
    jboss-datagrid72-openshift_1.0: registry.redhat.io/jboss-datagrid-7/datagrid72-openshift:1.0
    jboss-datagrid72-openshift_1.1: registry.redhat.io/jboss-datagrid-7/datagrid72-openshift:1.1
    jboss-datagrid72-openshift_1.2: registry.redhat.io/jboss-datagrid-7/datagrid72-openshift:1.2
    jboss-datagrid73-openshift_1.0: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.0
    jboss-datagrid73-openshift_1.1: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.1
    jboss-datagrid73-openshift_1.2: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.2
    jboss-datagrid73-openshift_1.3: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3
    jboss-datagrid73-openshift_1.4: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.4
    jboss-datavirt64-driver-openshift_1.0: registry.redhat.io/jboss-datavirt-6/datavirt64-driver-openshift:1.0
    jboss-datavirt64-driver-openshift_1.1: registry.redhat.io/jboss-datavirt-6/datavirt64-driver-openshift:1.1
    jboss-datavirt64-driver-openshift_1.2: registry.redhat.io/jboss-datavirt-6/datavirt64-driver-openshift:1.2
    jboss-datavirt64-driver-openshift_1.3: registry.redhat.io/jboss-datavirt-6/datavirt64-driver-openshift:1.3
    jboss-datavirt64-driver-openshift_1.4: registry.redhat.io/jboss-datavirt-6/datavirt64-driver-openshift:1.4
    jboss-datavirt64-driver-openshift_1.5: registry.redhat.io/jboss-datavirt-6/datavirt64-driver-openshift:1.5
    jboss-datavirt64-driver-openshift_1.6: registry.redhat.io/jboss-datavirt-6/datavirt64-driver-openshift:1.6
    jboss-datavirt64-driver-openshift_1.7: registry.redhat.io/jboss-datavirt-6/datavirt64-driver-openshift:1.7
    jboss-datavirt64-openshift_1.0: registry.redhat.io/jboss-datavirt-6/datavirt64-openshift:1.0
    jboss-datavirt64-openshift_1.1: registry.redhat.io/jboss-datavirt-6/datavirt64-openshift:1.1
    jboss-datavirt64-openshift_1.2: registry.redhat.io/jboss-datavirt-6/datavirt64-openshift:1.2
    jboss-datavirt64-openshift_1.3: registry.redhat.io/jboss-datavirt-6/datavirt64-openshift:1.3
    jboss-datavirt64-openshift_1.4: registry.redhat.io/jboss-datavirt-6/datavirt64-openshift:1.4
    jboss-datavirt64-openshift_1.5: registry.redhat.io/jboss-datavirt-6/datavirt64-openshift:1.5
    jboss-datavirt64-openshift_1.6: registry.redhat.io/jboss-datavirt-6/datavirt64-openshift:1.6
    jboss-datavirt64-openshift_1.7: registry.redhat.io/jboss-datavirt-6/datavirt64-openshift:1.7
    jboss-decisionserver64-openshift_1.0: registry.redhat.io/jboss-decisionserver-6/decisionserver64-openshift:1.0
    jboss-decisionserver64-openshift_1.1: registry.redhat.io/jboss-decisionserver-6/decisionserver64-openshift:1.1
    jboss-decisionserver64-openshift_1.2: registry.redhat.io/jboss-decisionserver-6/decisionserver64-openshift:1.2
    jboss-decisionserver64-openshift_1.3: registry.redhat.io/jboss-decisionserver-6/decisionserver64-openshift:1.3
    jboss-decisionserver64-openshift_1.4: registry.redhat.io/jboss-decisionserver-6/decisionserver64-openshift:1.4
    jboss-decisionserver64-openshift_1.5: registry.redhat.io/jboss-decisionserver-6/decisionserver64-openshift:1.5
    jboss-decisionserver64-openshift_1.6: registry.redhat.io/jboss-decisionserver-6/decisionserver64-openshift:1.6
    jboss-eap64-openshift_1.1: registry.redhat.io/jboss-eap-6/eap64-openshift:1.1
    jboss-eap64-openshift_1.2: registry.redhat.io/jboss-eap-6/eap64-openshift:1.2
    jboss-eap64-openshift_1.3: registry.redhat.io/jboss-eap-6/eap64-openshift:1.3
    jboss-eap64-openshift_1.4: registry.redhat.io/jboss-eap-6/eap64-openshift:1.4
    jboss-eap64-openshift_1.5: registry.redhat.io/jboss-eap-6/eap64-openshift:1.5
    jboss-eap64-openshift_1.6: registry.redhat.io/jboss-eap-6/eap64-openshift:1.6
    jboss-eap64-openshift_1.7: registry.redhat.io/jboss-eap-6/eap64-openshift:1.7
    jboss-eap64-openshift_1.8: registry.redhat.io/jboss-eap-6/eap64-openshift:1.8
    jboss-eap64-openshift_1.9: registry.redhat.io/jboss-eap-6/eap64-openshift:1.9
    jboss-eap64-openshift_latest: registry.redhat.io/jboss-eap-6/eap64-openshift:latest
    jboss-eap70-openshift_1.3: registry.redhat.io/jboss-eap-7/eap70-openshift:1.3
    jboss-eap70-openshift_1.4: registry.redhat.io/jboss-eap-7/eap70-openshift:1.4
    jboss-eap70-openshift_1.5: registry.redhat.io/jboss-eap-7/eap70-openshift:1.5
    jboss-eap70-openshift_1.6: registry.redhat.io/jboss-eap-7/eap70-openshift:1.6
    jboss-eap70-openshift_1.7: registry.redhat.io/jboss-eap-7/eap70-openshift:1.7
    jboss-eap71-openshift_1.1: registry.redhat.io/jboss-eap-7/eap71-openshift:1.1
    jboss-eap71-openshift_1.2: registry.redhat.io/jboss-eap-7/eap71-openshift:1.2
    jboss-eap71-openshift_1.3: registry.redhat.io/jboss-eap-7/eap71-openshift:1.3
    jboss-eap71-openshift_1.4: registry.redhat.io/jboss-eap-7/eap71-openshift:1.4
    jboss-eap71-openshift_latest: registry.redhat.io/jboss-eap-7/eap71-openshift:latest
    jboss-eap72-openjdk11-openshift-rhel8_1.0: registry.redhat.io/jboss-eap-7/eap72-openjdk11-openshift-rhel8:1.0
    jboss-eap72-openjdk11-openshift-rhel8_1.1: registry.redhat.io/jboss-eap-7/eap72-openjdk11-openshift-rhel8:1.1
    jboss-eap72-openjdk11-openshift-rhel8_latest: registry.redhat.io/jboss-eap-7/eap72-openjdk11-openshift-rhel8:latest
    jboss-eap72-openshift_1.0: registry.redhat.io/jboss-eap-7/eap72-openshift:1.0
    jboss-eap72-openshift_1.1: registry.redhat.io/jboss-eap-7/eap72-openshift:1.1
    jboss-eap72-openshift_1.2: registry.redhat.io/jboss-eap-7/eap72-openshift:1.2
    jboss-eap72-openshift_latest: registry.redhat.io/jboss-eap-7/eap72-openshift:latest
    jboss-eap73-openjdk11-openshift_7.3: registry.redhat.io/jboss-eap-7/eap73-openjdk11-openshift-rhel8:latest
    jboss-eap73-openjdk11-openshift_7.3.0: registry.redhat.io/jboss-eap-7/eap73-openjdk11-openshift-rhel8:7.3.0
    jboss-eap73-openjdk11-openshift_latest: registry.redhat.io/jboss-eap-7/eap73-openjdk11-openshift-rhel8:latest
    jboss-eap73-openjdk11-runtime-openshift_7.3: registry.redhat.io/jboss-eap-7/eap73-openjdk11-runtime-openshift-rhel8:latest
    jboss-eap73-openjdk11-runtime-openshift_7.3.0: registry.redhat.io/jboss-eap-7/eap73-openjdk11-runtime-openshift-rhel8:7.3.0
    jboss-eap73-openjdk11-runtime-openshift_latest: registry.redhat.io/jboss-eap-7/eap73-openjdk11-runtime-openshift-rhel8:latest
    jboss-eap73-openshift_7.3: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:latest
    jboss-eap73-openshift_7.3.0: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.0
    jboss-eap73-openshift_latest: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:latest
    jboss-eap73-runtime-openshift_7.3: registry.redhat.io/jboss-eap-7/eap73-openjdk8-runtime-openshift-rhel7:latest
    jboss-eap73-runtime-openshift_7.3.0: registry.redhat.io/jboss-eap-7/eap73-openjdk8-runtime-openshift-rhel7:7.3.0
    jboss-eap73-runtime-openshift_latest: registry.redhat.io/jboss-eap-7/eap73-openjdk8-runtime-openshift-rhel7:latest
    jboss-fuse70-console_1.0: registry.redhat.io/fuse7/fuse-console:1.0
    jboss-fuse70-eap-openshift_1.0: registry.redhat.io/fuse7/fuse-eap-openshift:1.0
    jboss-fuse70-java-openshift_1.0: registry.redhat.io/fuse7/fuse-java-openshift:1.0
    jboss-fuse70-karaf-openshift_1.0: registry.redhat.io/fuse7/fuse-karaf-openshift:1.0
    jboss-processserver64-openshift_1.0: registry.redhat.io/jboss-processserver-6/processserver64-openshift:1.0
    jboss-processserver64-openshift_1.1: registry.redhat.io/jboss-processserver-6/processserver64-openshift:1.1
    jboss-processserver64-openshift_1.2: registry.redhat.io/jboss-processserver-6/processserver64-openshift:1.2
    jboss-processserver64-openshift_1.3: registry.redhat.io/jboss-processserver-6/processserver64-openshift:1.3
    jboss-processserver64-openshift_1.4: registry.redhat.io/jboss-processserver-6/processserver64-openshift:1.4
    jboss-processserver64-openshift_1.5: registry.redhat.io/jboss-processserver-6/processserver64-openshift:1.5
    jboss-processserver64-openshift_1.6: registry.redhat.io/jboss-processserver-6/processserver64-openshift:1.6
    jboss-webserver31-tomcat7-openshift_1.0: registry.redhat.io/jboss-webserver-3/webserver31-tomcat7-openshift:1.0
    jboss-webserver31-tomcat7-openshift_1.1: registry.redhat.io/jboss-webserver-3/webserver31-tomcat7-openshift:1.1
    jboss-webserver31-tomcat7-openshift_1.2: registry.redhat.io/jboss-webserver-3/webserver31-tomcat7-openshift:1.2
    jboss-webserver31-tomcat7-openshift_1.3: registry.redhat.io/jboss-webserver-3/webserver31-tomcat7-openshift:1.3
    jboss-webserver31-tomcat7-openshift_1.4: registry.redhat.io/jboss-webserver-3/webserver31-tomcat7-openshift:1.4
    jboss-webserver31-tomcat8-openshift_1.0: registry.redhat.io/jboss-webserver-3/webserver31-tomcat8-openshift:1.0
    jboss-webserver31-tomcat8-openshift_1.1: registry.redhat.io/jboss-webserver-3/webserver31-tomcat8-openshift:1.1
    jboss-webserver31-tomcat8-openshift_1.2: registry.redhat.io/jboss-webserver-3/webserver31-tomcat8-openshift:1.2
    jboss-webserver31-tomcat8-openshift_1.3: registry.redhat.io/jboss-webserver-3/webserver31-tomcat8-openshift:1.3
    jboss-webserver31-tomcat8-openshift_1.4: registry.redhat.io/jboss-webserver-3/webserver31-tomcat8-openshift:1.4
    jboss-webserver53-openjdk8-tomcat9-openshift_1.0: registry.redhat.io/jboss-webserver-5/webserver53-openjdk8-tomcat9-openshift-rhel7:1.0
    jboss-webserver53-openjdk8-tomcat9-openshift_latest: registry.redhat.io/jboss-webserver-5/webserver53-openjdk8-tomcat9-openshift-rhel7:latest
    jboss-webserver53-openjdk11-tomcat9-openshift_1.0: registry.redhat.io/jboss-webserver-5/webserver53-openjdk11-tomcat9-openshift-rhel7:1.0
    jboss-webserver53-openjdk11-tomcat9-openshift_latest: registry.redhat.io/jboss-webserver-5/webserver53-openjdk11-tomcat9-openshift-rhel7:latest
    jenkins-agent-base_latest: registry.redhat.io/openshift4/ose-jenkins-agent-base:latest
    jenkins-agent-maven_v4.0: registry.redhat.io/openshift4/ose-jenkins-agent-maven:v4.0
    jenkins-agent-nodejs_v4.0: registry.redhat.io/openshift4/ose-jenkins-agent-nodejs:v4.0
    jenkins_2: registry.redhat.io/openshift4/ose-jenkins:v4.0
    mariadb_10.2: registry.redhat.io/rhscl/mariadb-102-rhel7:latest
    mariadb_10.2-el7: registry.redhat.io/rhscl/mariadb-102-rhel7:latest
    mariadb_10.3: registry.redhat.io/rhscl/mariadb-103-rhel7:latest
    mariadb_10.3-el7: registry.redhat.io/rhscl/mariadb-103-rhel7:latest
    mariadb_10.3-el8: registry.redhat.io/rhel8/mariadb-103:latest
    mongodb_3.4: registry.redhat.io/rhscl/mongodb-34-rhel7:latest
    mongodb_3.6: registry.redhat.io/rhscl/mongodb-36-rhel7:latest
    mysql_8.0: registry.redhat.io/rhscl/mysql-80-rhel7:latest
    mysql_8.0-el7: registry.redhat.io/rhscl/mysql-80-rhel7:latest
    mysql_8.0-el8: registry.redhat.io/rhel8/mysql-80:latest
    nginx_1.14: registry.redhat.io/rhscl/nginx-114-rhel7:latest
    nginx_1.14-el7: registry.redhat.io/rhscl/nginx-114-rhel7:latest
    nginx_1.14-el8: registry.redhat.io/rhel8/nginx-114:latest
    nginx_1.16: registry.redhat.io/rhscl/nginx-116-rhel7:latest
    nginx_1.16-el7: registry.redhat.io/rhscl/nginx-116-rhel7:latest
    nginx_1.16-el8: registry.redhat.io/rhel8/nginx-116:latest
    nodejs_10: registry.redhat.io/rhscl/nodejs-10-rhel7:latest
    nodejs_10-ubi7: registry.redhat.io/ubi7/nodejs-10:latest
    nodejs_10-ubi8: registry.redhat.io/ubi8/nodejs-10:latest
    nodejs_12: registry.redhat.io/rhscl/nodejs-12-rhel7:latest
    nodejs_12-ubi7: registry.redhat.io/ubi7/nodejs-12:latest
    nodejs_12-ubi8: registry.redhat.io/ubi8/nodejs-12:latest
    openjdk-11-rhel7_1.0: registry.redhat.io/openjdk/openjdk-11-rhel7:1.0
    openjdk-11-rhel7_1.1: registry.redhat.io/openjdk/openjdk-11-rhel7:1.1
    openjdk-11-rhel8_1.0: registry.redhat.io/openjdk/openjdk-11-rhel8:1.0
    perl_5.26: registry.redhat.io/rhscl/perl-526-rhel7:latest
    perl_5.26-el7: registry.redhat.io/rhscl/perl-526-rhel7:latest
    perl_5.26-ubi8: registry.redhat.io/ubi8/perl-526:latest
    perl_5.30: registry.redhat.io/rhscl/perl-530-rhel7:latest
    perl_5.30-el7: registry.redhat.io/rhscl/perl-530-rhel7:latest
    php_7.2: registry.redhat.io/rhscl/php-72-rhel7:latest
    php_7.2-ubi7: registry.redhat.io/ubi7/php-72:latest
    php_7.2-ubi8: registry.redhat.io/ubi8/php-72:latest
    php_7.3: registry.redhat.io/rhscl/php-73-rhel7:latest
    php_7.3-ubi7: registry.redhat.io/ubi7/php-73:latest
    php_7.3-ubi8: registry.redhat.io/ubi8/php-73:latest
    postgresql_9.6: registry.redhat.io/rhscl/postgresql-96-rhel7:latest
    postgresql_9.6-el7: registry.redhat.io/rhscl/postgresql-96-rhel7:latest
    postgresql_9.6-el8: registry.redhat.io/rhel8/postgresql-96:latest
    postgresql_10: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
    postgresql_10-el7: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
    postgresql_10-el8: registry.redhat.io/rhel8/postgresql-10:latest
    postgresql_12: registry.redhat.io/rhscl/postgresql-12-rhel7:latest
    postgresql_12-el7: registry.redhat.io/rhscl/postgresql-12-rhel7:latest
    postgresql_12-el8: registry.redhat.io/rhel8/postgresql-12:latest
    python_2.7: registry.redhat.io/rhscl/python-27-rhel7:latest
    python_2.7-ubi7: registry.redhat.io/ubi7/python-27:latest
    python_2.7-ubi8: registry.redhat.io/ubi8/python-27:latest
    python_3.6: registry.redhat.io/rhscl/python-36-rhel7:latest
    python_3.6-ubi7: registry.redhat.io/ubi7/python-36:latest
    python_3.6-ubi8: registry.redhat.io/ubi8/python-36:latest
    python_3.8: registry.redhat.io/rhscl/python-38-rhel7:latest
    python_3.8-ubi7: registry.redhat.io/ubi7/python-38:latest
    python_3.8-ubi8: registry.redhat.io/ubi8/python-38:latest
    redhat-openjdk18-openshift_1.0: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.0
    redhat-openjdk18-openshift_1.1: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.1
    redhat-openjdk18-openshift_1.2: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.2
    redhat-openjdk18-openshift_1.3: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.3
    redhat-openjdk18-openshift_1.4: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.4
    redhat-openjdk18-openshift_1.5: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.5
    redhat-openjdk18-openshift_1.6: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.6
    redhat-openjdk18-openshift_1.7: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.7
    redhat-openjdk18-openshift_1.8: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8
    redhat-sso70-openshift_1.3: registry.redhat.io/redhat-sso-7/sso70-openshift:1.3
    redhat-sso70-openshift_1.4: registry.redhat.io/redhat-sso-7/sso70-openshift:1.4
    redhat-sso71-openshift_1.0: registry.redhat.io/redhat-sso-7/sso71-openshift:1.0
    redhat-sso71-openshift_1.1: registry.redhat.io/redhat-sso-7/sso71-openshift:1.1
    redhat-sso71-openshift_1.2: registry.redhat.io/redhat-sso-7/sso71-openshift:1.2
    redhat-sso71-openshift_1.3: registry.redhat.io/redhat-sso-7/sso71-openshift:1.3
    redhat-sso72-openshift_1.0: registry.redhat.io/redhat-sso-7/sso72-openshift:1.0
    redhat-sso72-openshift_1.1: registry.redhat.io/redhat-sso-7/sso72-openshift:1.1
    redhat-sso72-openshift_1.2: registry.redhat.io/redhat-sso-7/sso72-openshift:1.2
    redhat-sso72-openshift_1.3: registry.redhat.io/redhat-sso-7/sso72-openshift:1.3
    redhat-sso72-openshift_1.4: registry.redhat.io/redhat-sso-7/sso72-openshift:1.4
    redhat-sso73-openshift_1.0: registry.redhat.io/redhat-sso-7/sso73-openshift:1.0
    redhat-sso73-openshift_latest: registry.redhat.io/redhat-sso-7/sso73-openshift:1.0
    redis_5: registry.redhat.io/rhscl/redis-5-rhel7:latest
    redis_5-el7: registry.redhat.io/rhscl/redis-5-rhel7:latest
    redis_5-el8: registry.redhat.io/rhel8/redis-5:latest
    rhdm-decisioncentral-rhel8_7.8.0: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.8.0
    rhdm-kieserver-rhel8_7.8.0: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.8.0
    rhpam-businesscentral-monitoring-rhel8_7.8.0: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.8.0
    rhpam-businesscentral-rhel8_7.8.0: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.8.0
    rhpam-kieserver-rhel8_7.8.0: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.8.0
    rhpam-smartrouter-rhel8_7.8.0: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.8.0
    ruby_2.5: registry.redhat.io/rhscl/ruby-25-rhel7:latest
    ruby_2.5-ubi7: registry.redhat.io/ubi7/ruby-25:latest
    ruby_2.5-ubi8: registry.redhat.io/ubi8/ruby-25:latest
    ruby_2.6: registry.redhat.io/rhscl/ruby-26-rhel7:latest
    ruby_2.6-ubi7: registry.redhat.io/ubi7/ruby-26:latest
    ruby_2.6-ubi8: registry.redhat.io/ubi8/ruby-26:latest
    ruby_2.7: registry.redhat.io/rhscl/ruby-27-rhel7:latest
    ruby_2.7-ubi7: registry.redhat.io/ubi7/ruby-27:latest
    sso74-openshift-rhel8_7.4: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
    ubi8-openjdk-8_1.3: registry.access.redhat.com/ubi8/openjdk-8:1.3
    ubi8-openjdk-11_1.3: registry.access.redhat.com/ubi8/openjdk-11:1.3
```