### PR TITLE
Bug 1886890: Override jenkins-agent-base imagestream

### DIFF
--- a/manifests/06-operator.yaml
+++ b/manifests/06-operator.yaml
@@ -60,6 +60,8 @@ spec:
             value: "0.0.1-snapshot"
           - name: IMAGE_JENKINS
             value: quay.io/openshift/origin-jenkins:latest
+          - name: IMAGE_AGENT_BASE
+            value: quay.io/openshift/origin-jenkins-agent-base:latest
           - name: IMAGE_AGENT_NODEJS
             value: quay.io/openshift/origin-jenkins-agent-nodejs:latest
           - name: IMAGE_AGENT_MAVEN

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -30,6 +30,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-jenkins:latest
+  - name: jenkins-agent-base
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-jenkins-agent-base:latest
   - name: jenkins-agent-nodejs
     from:
       kind: DockerImage

--- a/pkg/stub/imagestreams.go
+++ b/pkg/stub/imagestreams.go
@@ -278,6 +278,8 @@ func (h *Handler) updateDockerPullSpec(oldies []string, imagestream *imagev1.Ima
 	switch imagestream.Name {
 	case "jenkins":
 		return
+	case "jenkins-agent-base":
+		return
 	case "jenkins-agent-nodejs":
 		return
 	case "jenkins-agent-maven":

--- a/pkg/stub/jenkins.go
+++ b/pkg/stub/jenkins.go
@@ -30,6 +30,8 @@ func jenkinsOverrides(imagestream *imagev1.ImageStream) *imagev1.ImageStream {
 	switch {
 	case imagestream.Name == "jenkins":
 		return tagInPayload("2", "IMAGE_JENKINS", imagestream)
+	case imagestream.Name == "jenkins-agent-base":
+		return tagInPayload("latest", "IMAGE_AGENT_BASE", imagestream)
 	case imagestream.Name == "jenkins-agent-maven":
 		return tagInPayload("v4.0", "IMAGE_AGENT_MAVEN", imagestream)
 	case imagestream.Name == "jenkins-agent-nodejs":


### PR DESCRIPTION
Just like jenkins-agent-maven and jenkins-agent-nodejs, derive the
pullspec for jenkins-agent-base from the release payload.

I'm thinking this should be backported to 4.6 as well so that it doesn't
start picking up 4.7+ versions once those GA.
