### PR TITLE
Add hello-openshift imagestream

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -112,3 +112,17 @@ spec:
       from:
         kind: DockerImage
         name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: hello-openshift
+spec:
+  tags:
+  - name: latest
+    importPolicy:
+      scheduled: true
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/hello-openshift:latest

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -54,3 +54,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
+  - name: hello-openshift
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/hello-openshift:latest


### PR DESCRIPTION
This should make it easier for existing uses of hello-openshift to move
to the official image (just added to 4.7).

/cc @sgreene570
