### PR TITLE
set progressing false on imagestream events as well if no active streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The samples resource maintains the following conditions in its status:
 -- False when all imagestream changes are acknowledged 
 -- The list of pending imagestreams will be represented by a configmap for each imagestream in the samples operator's namespace (where the imagestream name is the configmap name).  When the imagestream has completed imports, the respective configmap for the imagestream is deleted.
 - ImportCredentialsExist
--- A 'samples-registry-credentials' secret has been copied into the openshift namespace
+-- Credentials for pulling from `registry.redhat.io` exist in the `pull-secret` Secret in the `openshift-config` namespace
 - ConfigurationValid
 -- True or false based on whether any of the restricted changes noted above have been submitted
 - RemovePending
@@ -78,7 +78,7 @@ The samples resource maintains the following conditions in its status:
 -- True when an error has occurred
 -- The configmap associated with the imagestream will remain in the samples operator's namespace.  There will be a key in the configmap's data map for each imagestreamtag, where the value of the entry will be the error message reported in the imagestream status.
 - MigrationInProgress
--- True when the samples operator has detected that its version is different than the samples operator version the current samples set were installed with
+-- This condition is deprecated as of the 4.7 branch of this repository.  Upgrade tracking is now achieved via the other conditions and both the per imagestream configmaps and the imagestream-to-image configmap. 
 
 # CVO Cluster Operator Status
 

--- a/pkg/stub/config.go
+++ b/pkg/stub/config.go
@@ -221,16 +221,13 @@ func (h *Handler) buildFileMaps(cfg *v1.Config, forceRebuild bool) error {
 		cm = &corev1.ConfigMap{}
 		cm.Name = util.IST2ImageMap
 		cm.Namespace = v1.OperatorNamespace
-		if cm.Annotations == nil {
-			cm.Annotations = map[string]string{}
-		}
+		cm.Annotations = map[string]string{}
 		cm.Annotations[v1.SamplesVersionAnnotation] = h.version
 		cm.Data = map[string]string{}
 		for key, value := range h.imagestreatagToImage {
 			cm.Data[key] = value
 		}
-		_, err = h.configmapclientwrapper.Create(cm)
-		if err != nil {
+		if _, err = h.configmapclientwrapper.Create(cm); err != nil {
 			return err
 		}
 	}

--- a/pkg/stub/config.go
+++ b/pkg/stub/config.go
@@ -221,6 +221,10 @@ func (h *Handler) buildFileMaps(cfg *v1.Config, forceRebuild bool) error {
 		cm = &corev1.ConfigMap{}
 		cm.Name = util.IST2ImageMap
 		cm.Namespace = v1.OperatorNamespace
+		if cm.Annotations == nil {
+			cm.Annotations = map[string]string{}
+		}
+		cm.Annotations[v1.SamplesVersionAnnotation] = h.version
 		cm.Data = map[string]string{}
 		for key, value := range h.imagestreatagToImage {
 			cm.Data[key] = value
@@ -228,6 +232,24 @@ func (h *Handler) buildFileMaps(cfg *v1.Config, forceRebuild bool) error {
 		_, err = h.configmapclientwrapper.Create(cm)
 		if err != nil {
 			return err
+		}
+	}
+	if err == nil {
+		if cm.Annotations == nil {
+			cm.Annotations = map[string]string{}
+		}
+		version, ok := cm.Annotations[v1.SamplesVersionAnnotation]
+		if !ok || version != h.version {
+			logrus.Printf("Updating %s configmap to version %s", util.IST2ImageMap, h.version)
+			cm.Annotations[v1.SamplesVersionAnnotation] = h.version
+			cm.Data = map[string]string{}
+			for key, value := range h.imagestreatagToImage {
+				cm.Data[key] = value
+			}
+			_, err = h.configmapclientwrapper.Update(cm)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/test/e2e/cluster_samples_operator_test.go
+++ b/test/e2e/cluster_samples_operator_test.go
@@ -1146,16 +1146,6 @@ func coreTestUpgrade(t *testing.T) {
 		t.Fatalf("problem updating deployment env")
 	}
 
-	if cfg.Status.ManagementState == operatorsv1api.Managed {
-		err = wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
-			cfg := verifyOperatorUp(t)
-			if util.ConditionTrue(cfg, samplesapi.MigrationInProgress) {
-				return true, nil
-			}
-			return false, nil
-		})
-	}
-
 	if err != nil {
 		dumpPod(t)
 		t.Fatalf("did not enter migration mode in time %#v", verifyOperatorUp(t))


### PR DESCRIPTION
Seen a few runs in CI today for various repos fail where the the samples operator did not get out of progressing == true state

When examining the pods logs, some odd message after our attempt to update progressing to false after getting a configmap delete event failed:

```
2020-11-12T17:29:36.043718980Z W1112 17:29:36.043675      16 reflector.go:424] github.com/openshift/client-go/image/informers/externalversions/factory.go:101: watch of *v1.ImageStream ended with: an error on the server ("unable to decode an event from the watch stream: stream error: stream ID 225; INTERNAL_ERROR") has prevented the request from succeeding
2020-11-12T17:29:45.622049521Z time="2020-11-12T17:29:45Z" level=info msg="CRDERROR progressing false update"
2020-11-12T17:29:45.622089759Z time="2020-11-12T17:29:45Z" level=error msg="unable to sync: context deadline exceeded, requeuing"
2020-11-12T17:29:51.556538089Z time="2020-11-12T17:29:51Z" level=error msg="unable to sync: Timeout: request did not complete within requested timeout 34s, requeuing"
```

Even with returning an error, the delete event for the config map is not requeued.

We continue to get imagestream events.

This change (re)adds attempts to set progressing to false on imagestream events as well, when it is clear all the imagestream configmaps are gone.  We may get a few conflicts when several imagestreams come in at the same time, but in the end that is no big  deal.