### PR TITLE
Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -4,8 +4,9 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
+    openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-cluster-samples-operator

--- a/manifests/010-prometheus-rules.yaml
+++ b/manifests/010-prometheus-rules.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   groups:

--- a/manifests/02-sa.yaml
+++ b/manifests/02-sa.yaml
@@ -7,4 +7,5 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/03-rbac-proxies-role-binding.yaml
+++ b/manifests/03-rbac-proxies-role-binding.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 subjects:
   - kind: ServiceAccount

--- a/manifests/03-rbac-proxies-role.yaml
+++ b/manifests/03-rbac-proxies-role.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 rules:
   - apiGroups:

--- a/manifests/03-rbac.yaml
+++ b/manifests/03-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
@@ -39,6 +40,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
@@ -67,6 +69,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
@@ -89,6 +92,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
@@ -107,6 +111,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount

--- a/manifests/04-openshift-rbac.yaml
+++ b/manifests/04-openshift-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount

--- a/manifests/05-kube-system-rbac.yaml
+++ b/manifests/05-kube-system-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
@@ -27,6 +28,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount

--- a/manifests/06-metricsservice.yaml
+++ b/manifests/06-metricsservice.yaml
@@ -5,8 +5,9 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    service.beta.openshift.io/serving-cert-secret-name: samples-operator-tls
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
+    service.beta.openshift.io/serving-cert-secret-name: samples-operator-tls
   labels:
     name: cluster-samples-operator
   name: metrics

--- a/manifests/06-operator.yaml
+++ b/manifests/06-operator.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1

--- a/manifests/06-servicemonitor.yaml
+++ b/manifests/06-servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:

--- a/manifests/07-clusteroperator.yaml
+++ b/manifests/07-clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec: {}
 status:

--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tags:
@@ -27,6 +28,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tags:
@@ -45,6 +47,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tags:
@@ -63,6 +66,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tags:
@@ -81,6 +85,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tags:
@@ -99,6 +104,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tags:
@@ -117,6 +123,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tags:
@@ -135,6 +142,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tags:
@@ -153,6 +161,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tags:

--- a/manifests/09-servicemonitor-rbac.yaml
+++ b/manifests/09-servicemonitor-rbac.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
@@ -28,6 +29,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all cluster-samples-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.