### PR TITLE
Update jenkins-rhel.json

### DIFF
--- a/assets/operator/ocp-s390x/jenkins/imagestreams/jenkins-rhel.json
+++ b/assets/operator/ocp-s390x/jenkins/imagestreams/jenkins-rhel.json
@@ -44,7 +44,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/openshift4/ose-jenkins:v4.0"
+					"name": "registry.redhat.io/openshift4/ose-jenkins:v4.4.0"
 				},
 				"generation": null,
 				"importPolicy": {},


### PR DESCRIPTION
v4.0 tag is no longer available on the Red Hat Registry. It can be replaced with any tag, but since other tags may also be deleted, I just simply wanted to use the latest tag. However, the pod has never skipped the readiness checks. So that, I tried v4.4.0 and worked perfectly.