### PR TITLE
Bug 1950236: OKD: replace some docker.io images with quay.io

### DIFF
--- a/assets/operator/okd-x86_64/nginx/imagestreams/nginx-centos.json
+++ b/assets/operator/okd-x86_64/nginx/imagestreams/nginx-centos.json
@@ -92,7 +92,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/nginx-116-centos7:latest"
+					"name": "docker.io/centos/nginx-116-centos8:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -158,7 +158,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay.io/centos7/nginx-114-centos8:latest"
+					"name": "docker.io/centos/nginx-114-centos8:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/okd-x86_64/ruby/imagestreams/ruby-centos.json
+++ b/assets/operator/okd-x86_64/ruby/imagestreams/ruby-centos.json
@@ -79,6 +79,27 @@
 				}
 			},
 			{
+				"name": "2.7",
+				"annotations": {
+					"description": "Build and run Ruby applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.7/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 2.7",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"supports": "ruby",
+					"tags": "builder,ruby,hidden"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "quay.io/centos7/ruby-27-centos7:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
 				"name": "2.6-ubi8",
 				"annotations": {
 					"description": "Build and run Ruby 2.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",


### PR DESCRIPTION
This would ensure the clusters are hitting docker.io less often. Centos8 images are not yet mirrored to quay.

TODO:
* [x] https://github.com/openshift/origin/pull/25949 to pass tests, as Ruby 2.5 is being removed in OKD
* [x] https://github.com/openshift/origin/pull/25972 to update dancer example as it defaults to deprecated Perl 5.26 removed in this PR
* [x] https://github.com/openshift/origin/pull/26017 to address `okd-e2e-aws-image-ecosystem` failures
* [x] https://github.com/sclorg/nginx-container/pull/144 + library update to fix wrong nginx 1.14 ref
* [x] https://github.com/sclorg/nginx-container/pull/145 to fix centos tag for centos8
* [x] https://github.com/sclorg/s2i-ruby-container/pull/318 + library update to add missing `ruby:2.7` tag and have `okd-e2e-aws-image-ecosystem` and `okd-e2e-aws-aws-builds` pass

Failure summary:
* `okd-e2e-aws-jenkins` - `[sig-arch] Only known images used by tests`:
```
Cluster accessed images that were not mirrored to the testing repository or already part of the cluster, see test/extended/util/image/README.md in the openshift/origin repo:  quay.io/redhat-developer/nfs-server:latest from pods:   ns/e2e-test-jenkins-pipeline-v7nsz pod/nfs-server node/ip-10-0-139-183.us-east-2.compute.internal
```
Not sure what's up with that, this PR doesn't touch tests