### PR TITLE
Add management workload annotations

### DIFF
--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-cluster-samples-operator

--- a/manifests/06-operator-ibm-cloud-managed.yaml
+++ b/manifests/06-operator-ibm-cloud-managed.yaml
@@ -12,6 +12,8 @@ spec:
       name: cluster-samples-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-samples-operator
     spec:

--- a/manifests/06-operator.yaml
+++ b/manifests/06-operator.yaml
@@ -14,6 +14,8 @@ spec:
       name: cluster-samples-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-samples-operator
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>