### PR TITLE
Bug 1950808: add DeepCopy to avoid SharedInformer cache mutation

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -117,6 +117,7 @@ func (sc *samplesCollector) Collect(ch chan<- prometheus.Metric) {
 		logrus.Infof("metrics sample config retrieval failed with: %s", err.Error())
 		return
 	}
+	cfg = cfg.DeepCopy()
 
 	if cfg.Spec.ManagementState == operatorv1.Removed ||
 		cfg.Spec.ManagementState == operatorv1.Unmanaged {

--- a/pkg/stub/files.go
+++ b/pkg/stub/files.go
@@ -16,7 +16,11 @@ import (
 func (h *Handler) processFiles(dir string, files []os.FileInfo, opcfg *v1.Config) error {
 	for _, file := range files {
 		if file.IsDir() {
-			logrus.Printf("processing subdir %s from dir %s", file.Name(), dir)
+			if opcfg.Status.Version != h.version {
+				logrus.Printf("processing subdir %s from dir %s", file.Name(), dir)
+			} else {
+				logrus.Debugf("processing subdir %s from dir %s", file.Name(), dir)
+			}
 			subfiles, err := h.Filefinder.List(dir + "/" + file.Name())
 			if err != nil {
 				return h.processError(opcfg, v1.SamplesExist, corev1.ConditionUnknown, err, "error reading in content: %v")
@@ -28,7 +32,11 @@ func (h *Handler) processFiles(dir string, files []os.FileInfo, opcfg *v1.Config
 
 			continue
 		}
-		logrus.Printf("processing file %s from dir %s", file.Name(), dir)
+		if opcfg.Status.Version != h.version {
+			logrus.Printf("processing file %s from dir %s", file.Name(), dir)
+		} else {
+			logrus.Debugf("processing file %s from dir %s", file.Name(), dir)
+		}
 
 		if strings.HasSuffix(dir, "imagestreams") {
 			path := dir + "/" + file.Name()

--- a/pkg/stub/imagestreams.go
+++ b/pkg/stub/imagestreams.go
@@ -41,6 +41,7 @@ func (h *Handler) processImageStreamWatchEvent(is *imagev1.ImageStream, deleted 
 		if cfg == nil {
 			return nil
 		}
+		cfg = h.refetchCfgMinimizeConflicts(cfg)
 
 		cfg = h.refetchCfgMinimizeConflicts(cfg)
 		cfg, err = h.processImportStatus(is, cfg)
@@ -93,6 +94,9 @@ func (h *Handler) processImageStreamWatchEvent(is *imagev1.ImageStream, deleted 
 		is = nil
 	}
 
+	if is != nil {
+		is = is.DeepCopy()
+	}
 	err = h.upsertImageStream(imagestream, is, cfg)
 	if err != nil {
 		if kerrors.IsAlreadyExists(err) {

--- a/pkg/stub/interfaces.go
+++ b/pkg/stub/interfaces.go
@@ -259,8 +259,9 @@ type generatedCRDWrapper struct {
 }
 
 func (g *generatedCRDWrapper) UpdateStatus(sr *v1.Config, dbg string) error {
+	srCopy := sr.DeepCopy()
 	return wait.Poll(3*time.Second, 30*time.Second, func() (bool, error) {
-		_, err := g.client.UpdateStatus(context.TODO(), sr, metav1.UpdateOptions{})
+		_, err := g.client.UpdateStatus(context.TODO(), srCopy, metav1.UpdateOptions{})
 		if err == nil {
 			return true, nil
 		}
@@ -276,8 +277,9 @@ func (g *generatedCRDWrapper) UpdateStatus(sr *v1.Config, dbg string) error {
 }
 
 func (g *generatedCRDWrapper) Update(sr *v1.Config) error {
+	srCopy := sr.DeepCopy()
 	return wait.Poll(3*time.Second, 30*time.Second, func() (bool, error) {
-		_, err := g.client.Update(context.TODO(), sr, metav1.UpdateOptions{})
+		_, err := g.client.Update(context.TODO(), srCopy, metav1.UpdateOptions{})
 		if err == nil {
 			return true, nil
 		}
@@ -303,5 +305,9 @@ func (g *generatedCRDWrapper) Create(sr *v1.Config) error {
 }
 
 func (g *generatedCRDWrapper) Get(name string) (*v1.Config, error) {
-	return g.lister.Get(name)
+	c, err := g.lister.Get(name)
+	if err == nil && c != nil {
+		return c.DeepCopy(), nil
+	}
+	return c, err
 }

--- a/pkg/stub/templates.go
+++ b/pkg/stub/templates.go
@@ -16,7 +16,7 @@ func (h *Handler) processTemplateWatchEvent(t *templatev1.Template, deleted bool
 	// we can observe high fetch rates on the config object)
 	// imagestream image import tracking necessitates, after initial install or upgrade, requires the
 	// fetch of the config object, so we did not rework to ordering of the version check within that method
-	if t.Annotations != nil && !deleted {
+	if t != nil && t.Annotations != nil && !deleted {
 		isv, ok := t.Annotations[v1.SamplesVersionAnnotation]
 		logrus.Debugf("Comparing template/%s version %s ok %v with git version %s", t.Name, isv, ok, h.version)
 		if ok && isv == h.version {
@@ -50,6 +50,9 @@ func (h *Handler) processTemplateWatchEvent(t *templatev1.Template, deleted bool
 	if deleted {
 		// set t to nil so upsert will create
 		t = nil
+	}
+	if t != nil {
+		t = t.DeepCopy()
 	}
 	err = h.upsertTemplate(template, t, cfg)
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -100,7 +100,7 @@ func Condition(s *samplev1.Config, c samplev1.ConfigConditionType) *samplev1.Con
 	if s.Status.Conditions != nil {
 		for _, rc := range s.Status.Conditions {
 			if rc.Type == c {
-				return &rc
+				return rc.DeepCopy()
 			}
 		}
 	}


### PR DESCRIPTION
adjust fsm status update grouping to account for deepcopies
reduce logging

manual pick of https://github.com/openshift/cluster-samples-operator/pull/369 for 4.7.z

bz set up so bots don't work well