### PR TITLE
Bug 1950809: add DeepCopy to avoid SharedInformer cache mutation

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -114,6 +114,7 @@ func (sc *samplesCollector) Collect(ch chan<- prometheus.Metric) {
 		logrus.Infof("metrics sample config retrieval failed with: %s", err.Error())
 		return
 	}
+	cfg = cfg.DeepCopy()
 
 	if cfg.Spec.ManagementState == operatorv1.Removed ||
 		cfg.Spec.ManagementState == operatorv1.Unmanaged {

--- a/pkg/stub/files.go
+++ b/pkg/stub/files.go
@@ -16,7 +16,11 @@ import (
 func (h *Handler) processFiles(dir string, files []os.FileInfo, opcfg *v1.Config) error {
 	for _, file := range files {
 		if file.IsDir() {
-			logrus.Printf("processing subdir %s from dir %s", file.Name(), dir)
+			if opcfg.Status.Version != h.version {
+				logrus.Printf("processing subdir %s from dir %s", file.Name(), dir)
+			} else {
+				logrus.Debugf("processing subdir %s from dir %s", file.Name(), dir)
+			}
 			subfiles, err := h.Filefinder.List(dir + "/" + file.Name())
 			if err != nil {
 				return h.processError(opcfg, v1.SamplesExist, corev1.ConditionUnknown, err, "error reading in content: %v")
@@ -28,7 +32,11 @@ func (h *Handler) processFiles(dir string, files []os.FileInfo, opcfg *v1.Config
 
 			continue
 		}
-		logrus.Printf("processing file %s from dir %s", file.Name(), dir)
+		if opcfg.Status.Version != h.version {
+			logrus.Printf("processing file %s from dir %s", file.Name(), dir)
+		} else {
+			logrus.Debugf("processing file %s from dir %s", file.Name(), dir)
+		}
 
 		if strings.HasSuffix(dir, "imagestreams") {
 			path := dir + "/" + file.Name()

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -161,6 +161,8 @@ func (h *Handler) prepSamplesWatchEvent(kind, name string, annotations map[strin
 		return nil, "", false, false, err
 	}
 
+	cfg = cfg.DeepCopy()
+
 	if cfg.DeletionTimestamp != nil {
 		// we do no return the cfg in this case because we do not want to bother with any progress tracking
 		logrus.Printf("Received watch event %s but not upserting since deletion of the Config is in progress", kind+"/"+name)
@@ -195,7 +197,7 @@ func (h *Handler) prepSamplesWatchEvent(kind, name string, annotations map[strin
 	case "imagestream":
 		filePath, inInventory = h.imagestreamFile[name]
 		if !inInventory {
-			logrus.Printf("watch stream event %s not part of operators inventory", name)
+			logrus.Debugf("watch stream event %s not part of operators inventory", name)
 			// we now have cases where sample providers are deleting entire imagestreams;
 			// let's make sure there are no stale entries with inprogress / importerror
 			processing := util.Condition(cfg, v1.ImageChangesInProgress)
@@ -253,7 +255,9 @@ func (h *Handler) prepSamplesWatchEvent(kind, name string, annotations map[strin
 		// we have gotten events for items early in the migration list but we have not
 		// finished processing the list
 		// avoid (re)upsert, but check import status
-		logrus.Printf("watch event for %s/%s while migration in progress, image in progress is false; will not update sample because of this event", kind, name)
+		if util.ConditionTrue(cfg, v1.MigrationInProgress) {
+			logrus.Printf("watch event for %s/%s while migration in progress, image in progress is false; will not update sample because of this event", kind, name)
+		}
 		return cfg, "", false, false, nil
 	}
 
@@ -633,6 +637,7 @@ func (h *Handler) Handle(event util.Event) error {
 				if err != nil {
 					return err
 				}
+				cfg = h.refetchCfgMinimizeConflicts(cfg)
 				h.GoodConditionUpdate(cfg, corev1.ConditionFalse, v1.SamplesExist)
 				dbg := "exist false update"
 				logrus.Printf("CRDUPDATE %s", dbg)
@@ -643,6 +648,7 @@ func (h *Handler) Handle(event util.Event) error {
 				}
 			} else {
 				logrus.Println("Initiating finalizer processing for a SampleResource delete attempt")
+				cfg = h.refetchCfgMinimizeConflicts(cfg)
 				h.RemoveFinalizer(cfg)
 				dbg := "remove finalizer update"
 				logrus.Printf("CRDUPDATE %s", dbg)
@@ -745,6 +751,7 @@ func (h *Handler) Handle(event util.Event) error {
 
 				// once the status version is in sync, we can turn off the migration condition
 				if util.ConditionTrue(cfg, v1.MigrationInProgress) {
+					cfg = h.refetchCfgMinimizeConflicts(cfg)
 					h.GoodConditionUpdate(cfg, corev1.ConditionFalse, v1.MigrationInProgress)
 					dbg := " turn migration off"
 					logrus.Printf("CRDUPDATE %s", dbg)
@@ -766,15 +773,26 @@ func (h *Handler) Handle(event util.Event) error {
 			// in progress
 			if configChangeRequiresUpsert &&
 				util.ConditionTrue(cfg, v1.ImageChangesInProgress) {
+				cfg = h.refetchCfgMinimizeConflicts(cfg)
 				h.GoodConditionUpdate(cfg, corev1.ConditionFalse, v1.ImageChangesInProgress)
 				dbg := "change in progress from true to false for config change"
 				logrus.Printf("CRDUPDATE %s", dbg)
+				// do not transfer config changes to status since we are just turning off in progress
+				// to start a new createSamples cycle
 				return h.crdwrapper.UpdateStatus(cfg, dbg)
 			}
 		}
 
-		cfg.Status.ManagementState = operatorsv1api.Managed
+		cfg = h.refetchCfgMinimizeConflicts(cfg)
+		if cfg.Status.ManagementState != operatorsv1api.Managed {
+			cfg.Status.ManagementState = operatorsv1api.Managed
+			dbg := "change status management state to managed"
+			logrus.Printf("CRDUPDATE %s", dbg)
+			return h.crdwrapper.UpdateStatus(cfg, dbg)
+		}
+
 		// if coming from remove turn off
+		cfg = h.refetchCfgMinimizeConflicts(cfg)
 		if util.ConditionTrue(cfg, v1.RemovePending) {
 			now := kapis.Now()
 			condition := util.Condition(cfg, v1.RemovePending)
@@ -782,6 +800,9 @@ func (h *Handler) Handle(event util.Event) error {
 			condition.LastUpdateTime = now
 			condition.Status = corev1.ConditionFalse
 			util.ConditionUpdate(cfg, condition)
+			dbg := "change remove pending to false"
+			logrus.Printf("CRDUPDATE %s", dbg)
+			return h.crdwrapper.UpdateStatus(cfg, dbg)
 		}
 
 		cfg = h.refetchCfgMinimizeConflicts(cfg)
@@ -809,30 +830,13 @@ func (h *Handler) Handle(event util.Event) error {
 			dbg := "upd status version"
 			logrus.Printf("CRDUPDATE %s", dbg)
 			return h.crdwrapper.UpdateStatus(cfg, dbg)
-			/*if cfg.ConditionFalse(cfg, v1.ImportImageErrorsExist) {
-				cfg.Status.Version = h.version
-				logrus.Printf("The samples are now at version %s", cfg.Status.Version)
-				logrus.Println("CRDUPDATE upd status version")
-				return h.crdwrapper.UpdateStatus(cfg)
-			}
-			logrus.Printf("An image import error occurred applying the latest configuration on version %s, problem resolution needed", h.version
-			return nil
-
-			*/
 		}
 
-		if len(cfg.Spec.Architectures) == 0 {
-			cfg = h.updateCfgArch(cfg)
-		}
-
-		h.StoreCurrentValidConfig(cfg)
-
-		// now that we have stored the skip lists in status,
 		// cycle through the skip lists and update the managed flag if needed
-		for _, name := range cfg.Status.SkippedTemplates {
+		for _, name := range cfg.Spec.SkippedTemplates {
 			h.setSampleManagedLabelToFalse("template", name)
 		}
-		for _, name := range cfg.Status.SkippedImagestreams {
+		for _, name := range cfg.Spec.SkippedImagestreams {
 			h.setSampleManagedLabelToFalse("imagestream", name)
 		}
 
@@ -841,15 +845,22 @@ func (h *Handler) Handle(event util.Event) error {
 		if configChangeRequiresImportErrorUpdate && !configChangeRequiresUpsert {
 			dbg := "config change did not require upsert but did change import errors"
 			logrus.Printf("CRDUPDATE %s", dbg)
+			cfg = h.refetchCfgMinimizeConflicts(cfg)
+			// we have now "processed" the config and are executing changes, transfer current spec to status
+			h.StoreCurrentValidConfig(cfg)
 			return h.crdwrapper.UpdateStatus(cfg, dbg)
 		}
 
 		if configChanged && !configChangeRequiresUpsert && util.ConditionTrue(cfg, v1.SamplesExist) {
 			dbg := "bypassing upserts for non invasive config change after initial create"
 			logrus.Printf("CRDUPDATE %s", dbg)
+			cfg = h.refetchCfgMinimizeConflicts(cfg)
+			// we have now "processed" the config and are executing changes, transfer current spec to status
+			h.StoreCurrentValidConfig(cfg)
 			return h.crdwrapper.UpdateStatus(cfg, dbg)
 		}
 
+		cfg = h.refetchCfgMinimizeConflicts(cfg)
 		if !util.ConditionTrue(cfg, v1.ImageChangesInProgress) {
 			// pass in true to force rebuild of maps, which we do here because at this point
 			// we have taken on some form of config change
@@ -868,7 +879,7 @@ func (h *Handler) Handle(event util.Event) error {
 			if abortForDelete {
 				// a delete has been initiated; let's revert in progress to false and allow the delete to complete,
 				// including its removal of any sample we might have upserted with the above createSamples call
-				h.GoodConditionUpdate(h.refetchCfgMinimizeConflicts(cfg), corev1.ConditionFalse, v1.ImageChangesInProgress)
+				h.GoodConditionUpdate(cfg, corev1.ConditionFalse, v1.ImageChangesInProgress)
 				// note, the imagestream watch cache gets cleared once the deletion/finalizer processing commences
 				dbg := "progressing false because delete has arrived"
 				logrus.Printf("CRDUPDATE %s", dbg)
@@ -876,7 +887,6 @@ func (h *Handler) Handle(event util.Event) error {
 			}
 
 			if err != nil {
-				cfg = h.refetchCfgMinimizeConflicts(cfg)
 				h.processError(cfg, v1.SamplesExist, corev1.ConditionUnknown, err, "error creating samples: %v")
 				dbg := "setting samples exists to unknown"
 				logrus.Printf("CRDUPDATE %s", dbg)
@@ -887,7 +897,6 @@ func (h *Handler) Handle(event util.Event) error {
 				return err
 			}
 			now := kapis.Now()
-			cfg = h.refetchCfgMinimizeConflicts(cfg)
 			progressing := util.Condition(cfg, v1.ImageChangesInProgress)
 			progressing.Reason = ""
 			progressing.Message = ""
@@ -909,6 +918,8 @@ func (h *Handler) Handle(event util.Event) error {
 				progressing.Status = corev1.ConditionTrue
 			} else {
 				logrus.Debugln("there are no imagestreams available for import")
+				// we have now "processed" the config and are executing changes, transfer current spec to status
+				h.StoreCurrentValidConfig(cfg)
 				// see if there are unskipped templates, to set SamplesExists to true
 				if !util.ConditionTrue(cfg, v1.SamplesExist) {
 					templatesProcessed := false
@@ -921,7 +932,6 @@ func (h *Handler) Handle(event util.Event) error {
 						break
 					}
 					if templatesProcessed {
-						cfg = h.refetchCfgMinimizeConflicts(cfg)
 						h.GoodConditionUpdate(cfg, corev1.ConditionTrue, v1.SamplesExist)
 						dbg := "exist true update templates only"
 						logrus.Printf("CRDUPDATE %s", dbg)
@@ -937,6 +947,9 @@ func (h *Handler) Handle(event util.Event) error {
 			// the conditions on create; so we do initialize here, which is our "step 1"
 			// of the "make a change" flow in our state machine
 			cfg = h.initConditions(cfg)
+
+			// we have now "processed" the config and are executing changes, transfer current spec to status
+			h.StoreCurrentValidConfig(cfg)
 
 			dbg := "progressing true update"
 			logrus.Printf("CRDUPDATE %s", dbg)
@@ -1006,6 +1019,7 @@ func (h *Handler) setSampleManagedLabelToFalse(kind, name string) error {
 		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			stream, err = h.imageclientwrapper.Get(name)
 			if err == nil && stream != nil && stream.Labels != nil {
+				stream = stream.DeepCopy()
 				label, _ := stream.Labels[v1.SamplesManagedLabel]
 				if label == "true" {
 					stream.Labels[v1.SamplesManagedLabel] = "false"
@@ -1019,6 +1033,7 @@ func (h *Handler) setSampleManagedLabelToFalse(kind, name string) error {
 		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			tpl, err = h.templateclientwrapper.Get(name)
 			if err == nil && tpl != nil && tpl.Labels != nil {
+				tpl = tpl.DeepCopy()
 				label, _ := tpl.Labels[v1.SamplesManagedLabel]
 				if label == "true" {
 					tpl.Labels[v1.SamplesManagedLabel] = "false"
@@ -1090,6 +1105,9 @@ func (h *Handler) createSamples(cfg *v1.Config, updateIfPresent, registryChanged
 			is = nil
 		}
 
+		if is != nil {
+			is = is.DeepCopy()
+		}
 		err = h.upsertImageStream(imagestream, is, cfg)
 		if err != nil {
 			if updateIfPresent {
@@ -1135,6 +1153,7 @@ func (h *Handler) createSamples(cfg *v1.Config, updateIfPresent, registryChanged
 			t = nil
 		}
 
+		t = t.DeepCopy()
 		err = h.upsertTemplate(template, t, cfg)
 		if err != nil {
 			return false, err
@@ -1149,9 +1168,9 @@ func (h *Handler) createSamples(cfg *v1.Config, updateIfPresent, registryChanged
 func (h *Handler) refetchCfgMinimizeConflicts(cfg *v1.Config) *v1.Config {
 	c, e := h.crdwrapper.Get(cfg.Name)
 	if e == nil {
-		return c
+		return c.DeepCopy()
 	}
-	return cfg
+	return cfg.DeepCopy()
 }
 
 func getTemplateClient(restconfig *restclient.Config) (*templatev1client.TemplateV1Client, error) {

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -539,7 +539,7 @@ func TestImageStreamEvent(t *testing.T) {
 	statuses := []corev1.ConditionStatus{corev1.ConditionFalse, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionFalse, corev1.ConditionFalse}
 	validate(true, err, "", cfg, conditions, statuses, t)
 	// expedite the stream events coming in
-	cache.ClearUpsertsCache()
+	//cache.ClearUpsertsCache()
 
 	tagVersion := int64(1)
 	is := &imagev1.ImageStream{
@@ -630,6 +630,7 @@ func TestImageStreamEvent(t *testing.T) {
 		},
 	}
 	h.processImageStreamWatchEvent(is, false)
+	cfg, _ = h.crdwrapper.Get(cfg.Name)
 	is = &imagev1.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "baz",

--- a/pkg/stub/imagestreams.go
+++ b/pkg/stub/imagestreams.go
@@ -46,6 +46,7 @@ func (h *Handler) processImageStreamWatchEvent(is *imagev1.ImageStream, deleted 
 		if cfg == nil {
 			return nil
 		}
+		cfg = h.refetchCfgMinimizeConflicts(cfg)
 
 		// if we initiated the change, it will be in our cache, and we want to process
 		// the in progress, import error conditions
@@ -162,6 +163,9 @@ func (h *Handler) processImageStreamWatchEvent(is *imagev1.ImageStream, deleted 
 
 	cache.AddUpsert(imagestream.Name)
 
+	if is != nil {
+		is = is.DeepCopy()
+	}
 	err = h.upsertImageStream(imagestream, is, cfg)
 	if err != nil {
 		cache.RemoveUpsert(imagestream.Name)

--- a/pkg/stub/interfaces.go
+++ b/pkg/stub/interfaces.go
@@ -219,8 +219,9 @@ type generatedCRDWrapper struct {
 }
 
 func (g *generatedCRDWrapper) UpdateStatus(sr *v1.Config, dbg string) error {
+	srCopy := sr.DeepCopy()
 	return wait.Poll(3*time.Second, 30*time.Second, func() (bool, error) {
-		_, err := g.client.UpdateStatus(context.TODO(), sr, metav1.UpdateOptions{})
+		_, err := g.client.UpdateStatus(context.TODO(), srCopy, metav1.UpdateOptions{})
 		if err == nil {
 			return true, nil
 		}
@@ -236,8 +237,9 @@ func (g *generatedCRDWrapper) UpdateStatus(sr *v1.Config, dbg string) error {
 }
 
 func (g *generatedCRDWrapper) Update(sr *v1.Config) error {
+	srCopy := sr.DeepCopy()
 	return wait.Poll(3*time.Second, 30*time.Second, func() (bool, error) {
-		_, err := g.client.Update(context.TODO(), sr, metav1.UpdateOptions{})
+		_, err := g.client.Update(context.TODO(), srCopy, metav1.UpdateOptions{})
 		if err == nil {
 			return true, nil
 		}
@@ -263,5 +265,9 @@ func (g *generatedCRDWrapper) Create(sr *v1.Config) error {
 }
 
 func (g *generatedCRDWrapper) Get(name string) (*v1.Config, error) {
-	return g.lister.Get(name)
+	c, err := g.lister.Get(name)
+	if err == nil && c != nil {
+		return c.DeepCopy(), nil
+	}
+	return c, err
 }

--- a/pkg/stub/templates.go
+++ b/pkg/stub/templates.go
@@ -16,7 +16,7 @@ func (h *Handler) processTemplateWatchEvent(t *templatev1.Template, deleted bool
 	// we can observe high fetch rates on the config object)
 	// imagestream image import tracking necessitates, after initial install or upgrade, requires the
 	// fetch of the config object, so we did not rework to ordering of the version check within that method
-	if t.Annotations != nil && !deleted {
+	if t != nil && t.Annotations != nil && !deleted {
 		isv, ok := t.Annotations[v1.SamplesVersionAnnotation]
 		logrus.Debugf("Comparing template/%s version %s ok %v with git version %s", t.Name, isv, ok, h.version)
 		if ok && isv == h.version {
@@ -50,6 +50,9 @@ func (h *Handler) processTemplateWatchEvent(t *templatev1.Template, deleted bool
 	if deleted {
 		// set t to nil so upsert will create
 		t = nil
+	}
+	if t != nil {
+		t = t.DeepCopy()
 	}
 	err = h.upsertTemplate(template, t, cfg)
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -100,7 +100,7 @@ func Condition(s *samplev1.Config, c samplev1.ConfigConditionType) *samplev1.Con
 	if s.Status.Conditions != nil {
 		for _, rc := range s.Status.Conditions {
 			if rc.Type == c {
-				return &rc
+				return rc.DeepCopy()
 			}
 		}
 	}


### PR DESCRIPTION
add DeepCopy to avoid SharedInformer cache mutation

no longer track in progress reason incrementally
as soon as imagestream reports in mark it as off the in progress list
clear our reason field only when all imagestreams report in

manual version of https://github.com/openshift/cluster-samples-operator/pull/370 ... the samples rewrite in 4.7 makes cherrypick bot untenable

also, based on 4.6 specifcs, the second commit adds some 4.6 unique optimizations for the in progress reason field where are no longer applicable after the 4.7 rework