### PR TITLE
Rename workload annotations

### DIFF
--- a/manifests/06-operator-ibm-cloud-managed.yaml
+++ b/manifests/06-operator-ibm-cloud-managed.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-samples-operator
     spec:

--- a/manifests/06-operator.yaml
+++ b/manifests/06-operator.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-samples-operator
     spec:


### PR DESCRIPTION
As per openshift/enhancements#739, the workload annotations names are changing.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged