### PR TITLE
Bug 1960334: manifests: fix selector in ServiceMonitor

### DIFF
--- a/manifests/06-servicemonitor.yaml
+++ b/manifests/06-servicemonitor.yaml
@@ -18,4 +18,5 @@ spec:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-cluster-samples-operator.svc
   selector:
-    name: cluster-samples-operator
+    matchLabels:
+      name: cluster-samples-operator


### PR DESCRIPTION
Invalid selector in ServiceMonitor makes CVO attempt to apply this manifest on every sync iteration