### PR TITLE
seed relatedObjects in manifest yaml

### DIFF
--- a/manifests/07-clusteroperator.yaml
+++ b/manifests/07-clusteroperator.yaml
@@ -8,6 +8,16 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 spec: {}
 status:
+  relatedObjects:
+    - group: samples.operator.openshift.io
+      name: cluster
+      resource: configs
+    - group: ""
+      name: openshift-cluster-samples-operator
+      resource: namespaces
+    - group: ""
+      name: openshift
+      resource: namespaces
   versions:
     - name: operator
       version: "0.0.1-snapshot"


### PR DESCRIPTION
Per http://mailman-int.corp.redhat.com/archives/aos-devel/2021-May/msg00139.html from @wking 

Note:  the operator fills out `RelatedObjects` in https://github.com/openshift/cluster-samples-operator/blob/c1b73fe82b9bee65b28f886dcc930a5205680d6c/pkg/operatorstatus/operatorstatus.go#L226-L230