### PR TITLE
Bug 1975539: delete hello-openshift in payload imagestream via CVO annotation

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -144,3 +144,27 @@ spec:
       from:
         kind: DockerImage
         name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
+---
+# we have to remove imagestreams here not via deletion, but per a CVO annotation
+# in order to properly conform with its conventions
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: hello-openshift
+  annotations:
+    release.openshift.io/delete: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      importPolicy:
+        scheduled: true
+      from:
+        kind: DockerImage
+        name: quay.io/openshift/origin-hello-openshift:latest


### PR DESCRIPTION
/assign @jottofar 

@jottofar please lgtm if I have interpreted https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/object-deletion.md and this bz correctly

I'm guessing I don't need to update `image-references` as well since this change is intended for deletion, but we'll see how the cluster install goes.  If there are complaints from the CVO around samples operator then that is the most likely explanation.

@dperaza4dustbit FYI ... these "in payload" imagestreams IIRC are also discussed in the skill xfer videos.