### PR TITLE
Bug 2001974: delete hello-openshift in payload imagestream via CVO annotation

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -144,3 +144,27 @@ spec:
       from:
         kind: DockerImage
         name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
+---
+# we have to remove imagestreams here not via deletion, but per a CVO annotation
+# in order to properly conform with its conventions
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: hello-openshift
+  annotations:
+    release.openshift.io/delete: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      importPolicy:
+        scheduled: true
+      from:
+        kind: DockerImage
+        name: quay.io/openshift/origin-hello-openshift:latest


### PR DESCRIPTION
cherry pick failed ... example https://github.com/openshift/cluster-samples-operator/pull/380#issuecomment-914382309

ultimately want to get this back to 4.7 .... see https://github.com/openshift/cluster-samples-operator/issues/385#issuecomment-914379957

/assign @dperaza4dustbit 

more tech debt I was still carrying prior to hand off 