### PR TITLE
Bug 2001977: delete hello-openshift in payload imagestream

### DIFF
--- a/assets/operator/okd-x86_64/ruby/imagestreams/ruby-centos.json
+++ b/assets/operator/okd-x86_64/ruby/imagestreams/ruby-centos.json
@@ -79,6 +79,24 @@
 				}
 			},
 			{
+				"name": "2.7",
+				"annotations": {
+					"openshift.io/display-name": "Ruby 2.7",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"description": "Build and run Ruby applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.7/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+					"iconClass": "icon-ruby",
+					"tags": "builder,ruby,hidden",
+					"supports": "ruby",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "quay.io/centos7/ruby-27-centos7:latest"
+				},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},			{
 				"name": "2.6-ubi8",
 				"annotations": {
 					"description": "Build and run Ruby 2.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",

--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -152,24 +152,3 @@ spec:
       from:
         kind: DockerImage
         name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
----
-kind: ImageStream
-apiVersion: image.openshift.io/v1
-metadata:
-  namespace: openshift
-  name: hello-openshift
-  annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
-spec:
-  lookupPolicy:
-    local: true
-  tags:
-  - name: latest
-    importPolicy:
-      scheduled: true
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-hello-openshift:latest

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -58,7 +58,3 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
-  - name: hello-openshift
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-hello-openshift:latest


### PR DESCRIPTION
cherry pick failed ... example https://github.com/openshift/cluster-samples-operator/pull/380#issuecomment-914382309

ultimately want to get this back to 4.7 .... see https://github.com/openshift/cluster-samples-operator/issues/385#issuecomment-914379957

/assign @dperaza4dustbit

more tech debt I was still carrying prior to hand off

NOTE: confirmed with @jottofar that the install feature of using an annotation to have CVO delete a given item it manages is not getting backported to 4.7, so we just have to remove the imagestream like we did in 4.8.