### PR TITLE
Bug 2007757: Including Template in must-gather related objects.

### DIFF
--- a/manifests/07-clusteroperator.yaml
+++ b/manifests/07-clusteroperator.yaml
@@ -15,9 +15,14 @@ status:
     - group: ""
       name: openshift-cluster-samples-operator
       resource: namespaces
-    - group: ""
-      name: openshift
-      resource: namespaces
+    - group: template.openshift.io
+      name: ""
+      resource: templates
+      namespace: openshift
+    - group: image.openshift.io
+      name: ""
+      resource: imagestreams
+      namespace: openshift
   versions:
     - name: operator
       version: "0.0.1-snapshot"

--- a/pkg/operatorstatus/operatorstatus.go
+++ b/pkg/operatorstatus/operatorstatus.go
@@ -14,6 +14,8 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/api/samples/v1"
+	templatev1 "github.com/openshift/api/template/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
 	"github.com/openshift/cluster-samples-operator/pkg/metrics"
@@ -226,7 +228,8 @@ func (o *ClusterOperatorHandler) setOperatorStatus(condtype configv1.ClusterStat
 		state.Status.RelatedObjects = []configv1.ObjectReference{
 			{Group: v1.GroupName, Resource: "configs", Name: "cluster"},
 			{Resource: "namespaces", Name: v1.OperatorNamespace},
-			{Resource: "namespaces", Name: "openshift"},
+			{Group: templatev1.GroupName, Resource: "templates", Name: "", Namespace: "openshift"},
+			{Group: imagev1.GroupName, Resource: "imagestreams", Name: "", Namespace: "openshift"},
 		}
 
 		return o.ClusterOperatorWrapper.UpdateStatus(state)


### PR DESCRIPTION
The must-gather tool is collecting imagestreams under the openshift
namespace but it is not collecting templates. Being more prescriptive
on the groups we want to collect for sample related objects.