### PR TITLE
Bug 2064610: Remove duplicate v1 from cakephp-mysql templates

### DIFF
--- a/assets/operator/ocp-aarch64/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/ocp-aarch64/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,7 +139,7 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {

--- a/assets/operator/ocp-ppc64le/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/ocp-ppc64le/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,7 +139,7 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {

--- a/assets/operator/ocp-s390x/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/ocp-s390x/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,7 +139,7 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {

--- a/assets/operator/ocp-x86_64/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/ocp-x86_64/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,7 +139,7 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {

--- a/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,7 +139,7 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {


### PR DESCRIPTION
I have already submitted PR for cakeph-ex: https://github.com/sclorg/cakephp-ex/pull/131 and for openshift library: https://github.com/openshift/library/pull/306. Fixing directly hear without synching so we can target this issue only for back porting to 4.10 

Signed-off-by: David Peraza <dperaza@redhat.com>