### PR TITLE
AUTH-133: manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/06-operator-ibm-cloud-managed.yaml
+++ b/manifests/06-operator-ibm-cloud-managed.yaml
@@ -41,6 +41,11 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /etc/secrets
           name: samples-operator-tls
@@ -59,7 +64,16 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: cluster-samples-operator
       shareProcessNamespace: true
       tolerations:

--- a/manifests/06-operator.yaml
+++ b/manifests/06-operator.yaml
@@ -23,6 +23,10 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - key: node-role.kubernetes.io/master  # Just tolerate NoSchedule taint on master node. If there are other conditions like disk-pressure etc, let's not schedule the control-plane pods onto that node.
         operator: Exists
@@ -51,6 +55,11 @@ spec:
           requests:
             memory: 50Mi
             cpu: 10m
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: samples-operator-tls
@@ -79,4 +88,8 @@ spec:
           requests:
             memory: 50Mi
             cpu: 10m
-
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-cluster-samples-operator/pods/",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": runAsNonRoot != true (pod or containers \"cluster-samples-operator\", \"cluster-samples-operator-watch\" must set securityContext.runAsNonRoot=true)"
}
```

/cc @stlaz 