### PR TITLE
Bug 2061950: Add latest tag to oauth-proxy imagestream

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -130,12 +130,20 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   tags:
-    - name: v4.4
+    - name: latest
       importPolicy:
         scheduled: true
       from:
         kind: DockerImage
-        name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
+        name: quay.io/openshift/origin-oauth-proxy:v4.0
+    - name: v4.4
+      annotations:
+        tags: "hidden"
+      importPolicy:
+        scheduled: true
+      from:
+        kind: DockerImage
+        name: quay.io/openshift/origin-oauth-proxy:v4.0
 ---
 # we have to remove imagestreams here not via deletion, but per a CVO annotation
 # in order to properly conform with its conventions

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -41,4 +41,4 @@ spec:
   - name: oauth-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
+      name: quay.io/openshift/origin-oauth-proxy:v4.0


### PR DESCRIPTION
The use of v4.4 is a historical vestige which has not aged well and is inconsistent with other such imagestreams which provide latest. However, the v4.4 IST is kept for compatibility.

/cc @wking @mfojtik 