### PR TITLE
Add client certificate and key to service monitor

### DIFF
--- a/manifests/06-servicemonitor.yaml
+++ b/manifests/06-servicemonitor.yaml
@@ -17,6 +17,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-cluster-samples-operator.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   selector:
     matchLabels:
       name: cluster-samples-operator


### PR DESCRIPTION
Added client certificates based on https://github.com/deads2k/openshift-enhancements/blob/master/enhancements/monitoring/client-cert-scraping.md