### PR TITLE
[release-4.11] OCPBUGS-2092: Use X.Y floating tags for golang

### DIFF
--- a/assets/operator/ocp-aarch64/golang/imagestreams/golang-rhel-aarch64.json
+++ b/assets/operator/ocp-aarch64/golang/imagestreams/golang-rhel-aarch64.json
@@ -47,7 +47,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi9/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -68,7 +68,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi8/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-ppc64le/golang/imagestreams/golang-rhel.json
+++ b/assets/operator/ocp-ppc64le/golang/imagestreams/golang-rhel.json
@@ -47,7 +47,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi9/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -68,7 +68,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi8/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -89,7 +89,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi7/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-s390x/golang/imagestreams/golang-rhel.json
+++ b/assets/operator/ocp-s390x/golang/imagestreams/golang-rhel.json
@@ -47,7 +47,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi9/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -68,7 +68,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi8/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -89,7 +89,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi7/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-x86_64/golang/imagestreams/golang-rhel.json
+++ b/assets/operator/ocp-x86_64/golang/imagestreams/golang-rhel.json
@@ -47,7 +47,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi9/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -68,7 +68,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi8/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -89,7 +89,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/go-toolset:1.17.7"
+					"name": "registry.redhat.io/ubi7/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/okd-x86_64/golang/imagestreams/golang-centos.json
+++ b/assets/operator/okd-x86_64/golang/imagestreams/golang-centos.json
@@ -47,7 +47,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi9/go-toolset:1.17.7"
+					"name": "registry.access.redhat.com/ubi9/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -68,7 +68,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/go-toolset:1.17.7"
+					"name": "registry.access.redhat.com/ubi8/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -89,7 +89,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi7/go-toolset:1.17.7"
+					"name": "registry.access.redhat.com/ubi7/go-toolset:1.17"
 				},
 				"generation": null,
 				"importPolicy": {},


### PR DESCRIPTION
This is a backport of https://github.com/sclorg/golang-container/pull/45 and the resulting https://github.com/openshift/library/commit/79279a759b7d7394ffbda2d250551e58bd67e44f for 4.11.

/cc @fbm3307
