### PR TITLE
Change importMode to preserveOriginal for Openshift imagestreams

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -14,6 +14,7 @@ spec:
   - name: latest
     importPolicy:
       scheduled: true
+      importMode: PreserveOriginal
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cli:v4.0
@@ -31,6 +32,7 @@ spec:
   - name: latest
     importPolicy:
       scheduled: true
+      importMode: PreserveOriginal
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cli-artifacts:v4.0
@@ -48,6 +50,7 @@ spec:
   - name: latest
     importPolicy:
       scheduled: true
+      importMode: PreserveOriginal
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-installer:v4.0
@@ -65,6 +68,7 @@ spec:
   - name: latest
     importPolicy:
       scheduled: true
+      importMode: PreserveOriginal
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-installer-artifacts:v4.0
@@ -82,6 +86,7 @@ spec:
   - name: latest
     importPolicy:
       scheduled: true
+      importMode: PreserveOriginal
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-tests:v4.0
@@ -99,6 +104,7 @@ spec:
   - name: latest
     importPolicy:
       scheduled: true
+      importMode: PreserveOriginal
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-tools:v4.0
@@ -116,6 +122,7 @@ spec:
     - name: latest
       importPolicy:
         scheduled: true
+        importMode: PreserveOriginal
       from:
         kind: DockerImage
         name: quay.io/openshift/origin-must-gather:v4.0
@@ -133,6 +140,7 @@ spec:
     - name: v4.4
       importPolicy:
         scheduled: true
+        importMode: PreserveOriginal
       from:
         kind: DockerImage
         name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
@@ -155,6 +163,7 @@ spec:
     - name: latest
       importPolicy:
         scheduled: true
+        importMode: PreserveOriginal
       from:
         kind: DockerImage
         name: quay.io/openshift/origin-hello-openshift:latest


### PR DESCRIPTION
With support landing for importing manifestlists in imagestreams (https://issues.redhat.com/browse/IR-192), making these import the manifestlist by default will help when clusters are installed with the manifestlisted multi release payload and compute nodes of different architectures are added. This will help the CI nightly test suites run without errors on a cluster with multi arch compute nodes and also enable commands like oc debug and must-gather to run on these nodes.