### PR TITLE
OCPBUGS-855: When setting allowedRegistries urls the openshift-samples operator is degraded

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -345,7 +345,7 @@ func redHatRegistriesFound(allowedRegistries map[string]bool) bool {
 	// - registry.access.redhat.com
 	// - quay.io
 	return allowedRegistries["registry.redhat.io"] &&
-		allowedRegistries["registry.access.redhat.io"] &&
+		allowedRegistries["registry.access.redhat.com"] &&
 		allowedRegistries["quay.io"]
 }
 
@@ -356,12 +356,22 @@ func redHatRegistriesDomainFound(allowedDomains map[string]bool) bool {
 	// - quay.io
 	// or a domain combination that covers above registries
 	return (allowedDomains["registry.redhat.io"] &&
-		allowedDomains["registry.access.redhat.io"] &&
+		allowedDomains["registry.access.redhat.com"] &&
 		allowedDomains["quay.io"]) ||
-		(allowedDomains["redhat.io"] &&
+		(allowedDomains["registry.redhat.io"] &&
+			allowedDomains["access.redhat.com"] &&
 			allowedDomains["quay.io"]) ||
 		(allowedDomains["registry.redhat.io"] &&
-			allowedDomains["access.redhat.io"] &&
+			allowedDomains["redhat.com"] &&
+			allowedDomains["quay.io"]) ||
+		(allowedDomains["redhat.io"] &&
+			allowedDomains["registry.access.redhat.com"] &&
+			allowedDomains["quay.io"]) ||
+		(allowedDomains["redhat.io"] &&
+			allowedDomains["access.redhat.com"] &&
+			allowedDomains["quay.io"]) ||
+		(allowedDomains["redhat.io"] &&
+			allowedDomains["redhat.com"] &&
 			allowedDomains["quay.io"])
 
 }
@@ -479,7 +489,7 @@ func (h *Handler) tbrInaccessible() bool {
 		return true
 	}
 	if h.imageConfigBlocksImageStreamCreation("registry.redhat.io") ||
-		h.imageConfigBlocksImageStreamCreation("registry.access.redhat.io") ||
+		h.imageConfigBlocksImageStreamCreation("registry.access.redhat.com") ||
 		h.imageConfigBlocksImageStreamCreation("quay.io") {
 		return true
 	}

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -308,7 +308,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 				Spec: configv1.ImageSpec{
 					AllowedRegistriesForImport: []configv1.RegistryLocation{
 						{
-							DomainName: "redhat.io",
+							DomainName: "registry.redhat.io",
 						},
 						{
 							DomainName: "quay.io",
@@ -328,7 +328,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 							DomainName: "registry.redhat.io",
 						},
 						{
-							DomainName: "access.redhat.io",
+							DomainName: "access.redhat.com",
 						},
 						{
 							DomainName: "quay.io",
@@ -348,7 +348,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 							DomainName: "registry.redhat.io",
 						},
 						{
-							DomainName: "registry.access.redhat.io",
+							DomainName: "registry.access.redhat.com",
 						},
 						{
 							DomainName: "quay.io",
@@ -382,7 +382,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 							DomainName: "quay.io",
 						},
 						{
-							DomainName: "access.redhat.io",
+							DomainName: "access.redhat.com",
 						},
 					},
 				},
@@ -399,7 +399,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 							DomainName: "quay.io",
 						},
 						{
-							DomainName: "registry.redhat.io",
+							DomainName: "redhat.io",
 						},
 					},
 				},
@@ -440,7 +440,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 					RegistrySources: configv1.RegistrySources{
 						AllowedRegistries: []string{
 							"registry.redhat.io",
-							"registry.access.redhat.io",
+							"registry.access.redhat.com",
 							"quay.io",
 						},
 					},
@@ -456,7 +456,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 					RegistrySources: configv1.RegistrySources{
 						AllowedRegistries: []string{
 							"registry.redhat.io",
-							"registry.access.redhat.io",
+							"registry.access.redhat.com",
 						},
 					},
 				},

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -316,7 +316,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 					},
 				},
 			},
-			ExpectedResult: false,
+			ExpectedResult: true,
 		},
 		{
 			Name:         "Test AllowRegistriesForImport whitelisted but empty registry name (2)",

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -339,7 +339,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 			ExpectedResult: false,
 		},
 		{
-			Name:         "Test AllowRegistriesForImport whitelisted but empty registry name (2)",
+			Name:         "Test AllowRegistriesForImport whitelisted but empty registry name (3)",
 			RegistryName: "",
 			ImageConfig: configv1.Image{
 				Spec: configv1.ImageSpec{
@@ -449,7 +449,34 @@ func buildBlockTestScenarios() []BlockTestScenario {
 			ExpectedResult: false,
 		},
 		{
-			Name:         "Test AllowRegistries not whitelisted but empty registry name",
+			Name:         "Test AllowRegistriesforimport and allowedregistries whitelisted but empty registry name",
+			RegistryName: "",
+			ImageConfig: configv1.Image{
+				Spec: configv1.ImageSpec{
+					AllowedRegistriesForImport: []configv1.RegistryLocation{
+						{
+							DomainName: "registry.redhat.io",
+						},
+						{
+							DomainName: "registry.access.redhat.com",
+						},
+						{
+							DomainName: "quay.io",
+						},
+					},
+					RegistrySources: configv1.RegistrySources{
+						AllowedRegistries: []string{
+							"registry.redhat.io",
+							"registry.access.redhat.com",
+							"quay.io",
+						},
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name:         "Test AllowRegistries not whitelisted but empty registry name(1)",
 			RegistryName: "",
 			ImageConfig: configv1.Image{
 				Spec: configv1.ImageSpec{
@@ -502,6 +529,18 @@ func buildBlockTestScenarios() []BlockTestScenario {
 		{
 			Name:         "Test BlockedRegistries not whitelisted",
 			RegistryName: "registry.redhat.io",
+			ImageConfig: configv1.Image{
+				Spec: configv1.ImageSpec{
+					RegistrySources: configv1.RegistrySources{
+						BlockedRegistries: []string{"quay.io"},
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		{
+			Name:         "Test BlockedRegistries not whitelisted",
+			RegistryName: "registry.access.redhat.com",
 			ImageConfig: configv1.Image{
 				Spec: configv1.ImageSpec{
 					RegistrySources: configv1.RegistrySources{


### PR DESCRIPTION
This is a fix for the ocpbug855

Signed-off-by: Feny Mehta <fbm3307@gmail.com>