### PR TITLE
OCPBUGS-10910: Add network tools imagestreams

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -167,3 +167,21 @@ spec:
       from:
         kind: DockerImage
         name: quay.io/openshift/origin-hello-openshift:latest
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: network-tools
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  tags:
+  - name: latest
+    importPolicy:
+      scheduled: true
+      importMode: PreserveOriginal
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-network-tools:4.13

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -42,3 +42,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
+  - name: network-tools
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-network-tools:4.13


### PR DESCRIPTION
The network tools image is used by certain tests in origin and the way that is done today [1] is by spinning up a pod with the CVO image and getting the network-tools image spec from inside the pod. This is not desirable and also doesn't work today when these tests run on a cluster with multi arch compute nodes.

This PR adds the network tools imagestreams so these tests can be changed to use the imagestream rather than inferring it through creating a pod today.

[1] https://github.com/openshift/origin/blob/master/test/extended/util/release.go#L32