### PR TITLE
Add UBI ImageStreams

### DIFF
--- a/assets/operator/ocp-aarch64/ubi/imagestreams/ubi-rhel.json
+++ b/assets/operator/ocp-aarch64/ubi/imagestreams/ubi-rhel.json
@@ -1,0 +1,160 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "image.openshift.io/v1",
+	"metadata": {
+		"name": "ubi",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "Red Hat Universal Base Image"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "ubi9"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/assets/operator/ocp-ppc64le/ubi/imagestreams/ubi-rhel.json
+++ b/assets/operator/ocp-ppc64le/ubi/imagestreams/ubi-rhel.json
@@ -1,0 +1,160 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "image.openshift.io/v1",
+	"metadata": {
+		"name": "ubi",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "Red Hat Universal Base Image"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "ubi9"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/assets/operator/ocp-s390x/ubi/imagestreams/ubi-rhel.json
+++ b/assets/operator/ocp-s390x/ubi/imagestreams/ubi-rhel.json
@@ -1,0 +1,160 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "image.openshift.io/v1",
+	"metadata": {
+		"name": "ubi",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "Red Hat Universal Base Image"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "ubi9"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/assets/operator/ocp-x86_64/ubi/imagestreams/ubi-rhel.json
+++ b/assets/operator/ocp-x86_64/ubi/imagestreams/ubi-rhel.json
@@ -1,0 +1,160 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "image.openshift.io/v1",
+	"metadata": {
+		"name": "ubi",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "Red Hat Universal Base Image"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "ubi9"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/assets/operator/okd-x86_64/ubi/imagestreams/ubi-centos.json
+++ b/assets/operator/okd-x86_64/ubi/imagestreams/ubi-centos.json
@@ -1,0 +1,160 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "image.openshift.io/v1",
+	"metadata": {
+		"name": "ubi",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "Red Hat Universal Base Image"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "ubi9"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi9-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 9 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-minimal",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Minimal",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "ubi8-micro",
+				"annotations": {
+					"description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities.",
+					"iconClass": "icon-redhat",
+					"openshift.io/display-name": "Red Hat Universal Base Image 8 Micro",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "redhat,hidden",
+					"version": "8"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8-micro:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}


### PR DESCRIPTION
Useful for:
* Injecting compiled Go/Rust binary into from a multi-stage build
* Generic images for installing 3rd party RPMs into, bash scripts etc