### PR TITLE
Migrate from DeploymentConfig to Deployment

### DIFF
--- a/assets/operator/ocp-aarch64/cakephp/templates/cakephp-mysql-example.json
+++ b/assets/operator/ocp-aarch64/cakephp/templates/cakephp-mysql-example.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -264,25 +264,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"cakephp-mysql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -308,8 +290,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -409,26 +391,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/ocp-aarch64/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -264,25 +264,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"cakephp-mysql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -325,8 +307,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -428,26 +410,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/dancer/templates/dancer-mysql-example.json
+++ b/assets/operator/ocp-aarch64/dancer/templates/dancer-mysql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -237,25 +237,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"dancer-mysql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -281,8 +263,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -382,26 +364,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:8.0-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/dancer/templates/dancer-mysql-persistent.json
+++ b/assets/operator/ocp-aarch64/dancer/templates/dancer-mysql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -237,25 +237,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"dancer-mysql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -298,8 +280,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -401,26 +383,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:8.0-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/django/templates/django-psql-example.json
+++ b/assets/operator/ocp-aarch64/django/templates/django-psql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -241,25 +241,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"django-psql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -285,8 +267,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -382,26 +364,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/django/templates/django-psql-persistent.json
+++ b/assets/operator/ocp-aarch64/django/templates/django-psql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -241,25 +241,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"django-psql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -302,8 +284,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -401,26 +383,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/httpd/templates/httpd-example.json
+++ b/assets/operator/ocp-aarch64/httpd/templates/httpd-example.json
@@ -122,8 +122,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",

--- a/assets/operator/ocp-aarch64/java/templates/openjdk-web-basic-s2i.json
+++ b/assets/operator/ocp-aarch64/java/templates/openjdk-web-basic-s2i.json
@@ -42,7 +42,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -135,8 +135,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -146,7 +146,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -155,7 +155,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-aarch64/jenkins/templates/jenkins-ephemeral-monitored.json
+++ b/assets/operator/ocp-aarch64/jenkins/templates/jenkins-ephemeral-monitored.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -179,27 +179,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"jenkins"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${JENKINS_IMAGE_STREAM_TAG}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-aarch64/jenkins/templates/jenkins-ephemeral.json
+++ b/assets/operator/ocp-aarch64/jenkins/templates/jenkins-ephemeral.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -179,27 +179,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"jenkins"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${JENKINS_IMAGE_STREAM_TAG}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-aarch64/jenkins/templates/jenkins-persistent-monitored.json
+++ b/assets/operator/ocp-aarch64/jenkins/templates/jenkins-persistent-monitored.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -200,27 +200,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"jenkins"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${JENKINS_IMAGE_STREAM_TAG}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-aarch64/jenkins/templates/jenkins-persistent.json
+++ b/assets/operator/ocp-aarch64/jenkins/templates/jenkins-persistent.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -200,27 +200,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"jenkins"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${JENKINS_IMAGE_STREAM_TAG}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-aarch64/mariadb/templates/mariadb-ephemeral.json
+++ b/assets/operator/ocp-aarch64/mariadb/templates/mariadb-ephemeral.json
@@ -58,8 +58,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -175,26 +175,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mariadb"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mariadb:${MARIADB_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/mariadb/templates/mariadb-persistent.json
+++ b/assets/operator/ocp-aarch64/mariadb/templates/mariadb-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -192,26 +192,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mariadb"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mariadb:${MARIADB_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/mysql/templates/mysql-ephemeral.json
+++ b/assets/operator/ocp-aarch64/mysql/templates/mysql-ephemeral.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-aarch64/mysql/templates/mysql-persistent.json
+++ b/assets/operator/ocp-aarch64/mysql/templates/mysql-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-aarch64/nginx/templates/nginx-example.json
+++ b/assets/operator/ocp-aarch64/nginx/templates/nginx-example.json
@@ -124,8 +124,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",

--- a/assets/operator/ocp-aarch64/nodejs/templates/nodejs-postgresql-example.json
+++ b/assets/operator/ocp-aarch64/nodejs/templates/nodejs-postgresql-example.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -241,25 +241,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"nodejs-postgresql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -285,8 +267,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -381,26 +363,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/nodejs/templates/nodejs-postgresql-persistent.json
+++ b/assets/operator/ocp-aarch64/nodejs/templates/nodejs-postgresql-persistent.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -241,25 +241,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"nodejs-postgresql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -302,8 +284,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -398,26 +380,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-aarch64/nodejs/templates/react-web-app-example.json
+++ b/assets/operator/ocp-aarch64/nodejs/templates/react-web-app-example.json
@@ -87,8 +87,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"app": "${NAME}"
@@ -129,25 +129,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"type": "ConfigChange"
-					},
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-aarch64/postgresql/templates/postgresql-ephemeral.json
+++ b/assets/operator/ocp-aarch64/postgresql/templates/postgresql-ephemeral.json
@@ -64,8 +64,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-aarch64/postgresql/templates/postgresql-persistent.json
+++ b/assets/operator/ocp-aarch64/postgresql/templates/postgresql-persistent.json
@@ -81,8 +81,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -193,27 +193,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			},
 			"status": {}
 		}

--- a/assets/operator/ocp-aarch64/rails/templates/rails-pgsql-persistent.json
+++ b/assets/operator/ocp-aarch64/rails/templates/rails-pgsql-persistent.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -341,8 +341,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-aarch64/rails/templates/rails-postgresql-example.json
+++ b/assets/operator/ocp-aarch64/rails/templates/rails-postgresql-example.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -324,8 +324,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-aarch64/redis/templates/redis-ephemeral.json
+++ b/assets/operator/ocp-aarch64/redis/templates/redis-ephemeral.json
@@ -60,8 +60,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -154,27 +154,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"redis"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "redis:${REDIS_VERSION}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			},
 			"status": {}
 		}

--- a/assets/operator/ocp-aarch64/redis/templates/redis-persistent.json
+++ b/assets/operator/ocp-aarch64/redis/templates/redis-persistent.json
@@ -77,8 +77,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -171,27 +171,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"redis"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "redis:${REDIS_VERSION}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			},
 			"status": {}
 		}

--- a/assets/operator/ocp-ppc64le/cakephp/templates/cakephp-mysql-example.json
+++ b/assets/operator/ocp-ppc64le/cakephp/templates/cakephp-mysql-example.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -264,25 +264,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"cakephp-mysql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -308,8 +290,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -409,26 +391,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/ocp-ppc64le/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -264,25 +264,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"cakephp-mysql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -325,8 +307,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -428,26 +410,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/dancer/templates/dancer-mysql-example.json
+++ b/assets/operator/ocp-ppc64le/dancer/templates/dancer-mysql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -237,25 +237,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"dancer-mysql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -281,8 +263,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -382,26 +364,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:8.0-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/dancer/templates/dancer-mysql-persistent.json
+++ b/assets/operator/ocp-ppc64le/dancer/templates/dancer-mysql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -237,25 +237,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"dancer-mysql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -298,8 +280,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -401,26 +383,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:8.0-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/django/templates/django-psql-example.json
+++ b/assets/operator/ocp-ppc64le/django/templates/django-psql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -241,25 +241,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"django-psql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -285,8 +267,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -382,26 +364,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/django/templates/django-psql-persistent.json
+++ b/assets/operator/ocp-ppc64le/django/templates/django-psql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -241,25 +241,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"django-psql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -302,8 +284,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -401,26 +383,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/eap/templates/eap-xp3-basic-s2i.json
+++ b/assets/operator/ocp-ppc64le/eap/templates/eap-xp3-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -65,7 +65,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -254,8 +254,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -265,7 +265,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -280,7 +280,7 @@
 							"com.redhat.component-version": "3.0",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q3",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -374,25 +374,7 @@
 						],
 						"terminationGracePeriodSeconds": 75
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${APPLICATION_NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/eap/templates/eap-xp4-basic-s2i.json
+++ b/assets/operator/ocp-ppc64le/eap/templates/eap-xp4-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -65,7 +65,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -254,8 +254,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -265,7 +265,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -275,7 +275,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"com.company": "Red_Hat",
-							"deploymentConfig": "${APPLICATION_NAME}",
+							"deployment": "${APPLICATION_NAME}",
 							"rht.comp": "EAP_XP",
 							"rht.comp_ver": "4.0",
 							"rht.prod_name": "Red_Hat_Runtimes",

--- a/assets/operator/ocp-ppc64le/eap/templates/eap74-basic-s2i.json
+++ b/assets/operator/ocp-ppc64le/eap/templates/eap74-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -65,7 +65,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -254,8 +254,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -265,7 +265,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -280,7 +280,7 @@
 							"com.redhat.component-version": "7.4",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q2",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -374,25 +374,7 @@
 						],
 						"terminationGracePeriodSeconds": 75
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${APPLICATION_NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/eap/templates/eap74-https-s2i.json
+++ b/assets/operator/ocp-ppc64le/eap/templates/eap74-https-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -89,7 +89,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -297,8 +297,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -308,7 +308,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -323,7 +323,7 @@
 							"com.redhat.component-version": "7.4",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q2",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-ppc64le/eap/templates/eap74-sso-s2i.json
+++ b/assets/operator/ocp-ppc64le/eap/templates/eap74-sso-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -89,7 +89,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -316,8 +316,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -327,7 +327,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -342,7 +342,7 @@
 							"com.redhat.component-version": "7.4",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q2",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -613,25 +613,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${APPLICATION_NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/httpd/templates/httpd-example.json
+++ b/assets/operator/ocp-ppc64le/httpd/templates/httpd-example.json
@@ -122,8 +122,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -181,25 +181,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"httpd-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/java/templates/openjdk-web-basic-s2i.json
+++ b/assets/operator/ocp-ppc64le/java/templates/openjdk-web-basic-s2i.json
@@ -42,7 +42,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -135,8 +135,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -146,7 +146,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -155,7 +155,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -187,25 +187,7 @@
 						],
 						"terminationGracePeriodSeconds": 75
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${APPLICATION_NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/jenkins/templates/jenkins-ephemeral-monitored.json
+++ b/assets/operator/ocp-ppc64le/jenkins/templates/jenkins-ephemeral-monitored.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -179,27 +179,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"jenkins"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${JENKINS_IMAGE_STREAM_TAG}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-ppc64le/jenkins/templates/jenkins-ephemeral.json
+++ b/assets/operator/ocp-ppc64le/jenkins/templates/jenkins-ephemeral.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -179,27 +179,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"jenkins"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${JENKINS_IMAGE_STREAM_TAG}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-ppc64le/jenkins/templates/jenkins-persistent-monitored.json
+++ b/assets/operator/ocp-ppc64le/jenkins/templates/jenkins-persistent-monitored.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -200,27 +200,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"jenkins"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${JENKINS_IMAGE_STREAM_TAG}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-ppc64le/jenkins/templates/jenkins-persistent.json
+++ b/assets/operator/ocp-ppc64le/jenkins/templates/jenkins-persistent.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -200,27 +200,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"jenkins"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${JENKINS_IMAGE_STREAM_TAG}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-ppc64le/mariadb/templates/mariadb-ephemeral.json
+++ b/assets/operator/ocp-ppc64le/mariadb/templates/mariadb-ephemeral.json
@@ -58,8 +58,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -175,26 +175,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mariadb"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mariadb:${MARIADB_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/mariadb/templates/mariadb-persistent.json
+++ b/assets/operator/ocp-ppc64le/mariadb/templates/mariadb-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -192,26 +192,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mariadb"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mariadb:${MARIADB_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/mysql/templates/mysql-ephemeral.json
+++ b/assets/operator/ocp-ppc64le/mysql/templates/mysql-ephemeral.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -192,27 +192,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			},
 			"status": {}
 		}

--- a/assets/operator/ocp-ppc64le/mysql/templates/mysql-persistent.json
+++ b/assets/operator/ocp-ppc64le/mysql/templates/mysql-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -192,26 +192,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/nginx/templates/nginx-example.json
+++ b/assets/operator/ocp-ppc64le/nginx/templates/nginx-example.json
@@ -124,8 +124,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -183,25 +183,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"nginx-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/nodejs/templates/nodejs-postgresql-example.json
+++ b/assets/operator/ocp-ppc64le/nodejs/templates/nodejs-postgresql-example.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -241,25 +241,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"nodejs-postgresql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -285,8 +267,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -381,26 +363,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/nodejs/templates/nodejs-postgresql-persistent.json
+++ b/assets/operator/ocp-ppc64le/nodejs/templates/nodejs-postgresql-persistent.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -241,25 +241,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"nodejs-postgresql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -302,8 +284,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -398,26 +380,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/nodejs/templates/react-web-app-example.json
+++ b/assets/operator/ocp-ppc64le/nodejs/templates/react-web-app-example.json
@@ -87,8 +87,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"app": "${NAME}"
@@ -129,25 +129,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"type": "ConfigChange"
-					},
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-ppc64le/postgresql/templates/postgresql-ephemeral.json
+++ b/assets/operator/ocp-ppc64le/postgresql/templates/postgresql-ephemeral.json
@@ -64,8 +64,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -176,27 +176,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			},
 			"status": {}
 		}

--- a/assets/operator/ocp-ppc64le/postgresql/templates/postgresql-persistent.json
+++ b/assets/operator/ocp-ppc64le/postgresql/templates/postgresql-persistent.json
@@ -81,8 +81,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -193,27 +193,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			},
 			"status": {}
 		}

--- a/assets/operator/ocp-ppc64le/rails/templates/rails-pgsql-persistent.json
+++ b/assets/operator/ocp-ppc64le/rails/templates/rails-pgsql-persistent.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -280,25 +280,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -341,8 +323,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -448,26 +430,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/rails/templates/rails-postgresql-example.json
+++ b/assets/operator/ocp-ppc64le/rails/templates/rails-postgresql-example.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -280,25 +280,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -324,8 +306,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -429,26 +411,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/redis/templates/redis-ephemeral.json
+++ b/assets/operator/ocp-ppc64le/redis/templates/redis-ephemeral.json
@@ -60,8 +60,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -154,27 +154,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"redis"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "redis:${REDIS_VERSION}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			},
 			"status": {}
 		}

--- a/assets/operator/ocp-ppc64le/redis/templates/redis-persistent.json
+++ b/assets/operator/ocp-ppc64le/redis/templates/redis-persistent.json
@@ -77,8 +77,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"
@@ -171,27 +171,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"redis"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "redis:${REDIS_VERSION}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			},
 			"status": {}
 		}

--- a/assets/operator/ocp-ppc64le/sso/templates/sso75-https.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso75-https.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -88,7 +88,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -136,8 +136,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -147,7 +147,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -156,7 +156,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -359,26 +359,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso75-openshift-rhel8:7.5",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/sso/templates/sso75-ocp4-x509-https.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso75-ocp4-x509-https.json
@@ -53,7 +53,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -80,7 +80,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -107,8 +107,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -118,7 +118,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -127,7 +127,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -282,26 +282,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso75-openshift-rhel8:7.5",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/sso/templates/sso75-ocp4-x509-postgresql-persistent.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso75-ocp4-x509-postgresql-persistent.json
@@ -54,7 +54,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -78,7 +78,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -105,7 +105,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -132,8 +132,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -143,7 +143,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -152,7 +152,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -331,31 +331,12 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso75-openshift-rhel8:7.5",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -365,7 +346,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -374,7 +355,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},
@@ -457,26 +438,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}-postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql13-for-sso75-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-ppc64le/sso/templates/sso75-postgresql-persistent.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso75-postgresql-persistent.json
@@ -39,7 +39,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -64,7 +64,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -88,7 +88,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -114,7 +114,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -162,8 +162,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -173,7 +173,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -182,7 +182,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -409,31 +409,12 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso75-openshift-rhel8:7.5",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -443,7 +424,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -452,7 +433,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},
@@ -535,26 +516,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}-postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql13-for-sso75-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-ppc64le/sso/templates/sso75-postgresql.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso75-postgresql.json
@@ -40,7 +40,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -66,7 +66,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -91,7 +91,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -117,7 +117,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -167,8 +167,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -179,7 +179,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -189,7 +189,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "server",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -416,31 +416,12 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso75-openshift-rhel8:7.5",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -451,7 +432,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -461,7 +442,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "database",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},
@@ -540,26 +521,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}-postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql13-for-sso75-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-https.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-https.json
@@ -39,7 +39,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -64,7 +64,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -91,7 +91,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -150,7 +150,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -159,7 +159,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -373,26 +373,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso76-openshift-rhel8:7.6",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-postgresql-persistent.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-postgresql-persistent.json
@@ -40,7 +40,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -66,7 +66,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -91,7 +91,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -118,7 +118,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -166,8 +166,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -177,7 +177,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -186,7 +186,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -424,31 +424,12 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso76-openshift-rhel8:7.6",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -458,7 +439,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -467,7 +448,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},
@@ -550,26 +531,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}-postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql13-for-sso76-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-postgresql.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-postgresql.json
@@ -41,7 +41,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -68,7 +68,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -94,7 +94,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -121,7 +121,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -171,8 +171,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -183,7 +183,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -193,7 +193,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "server",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -431,31 +431,12 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso76-openshift-rhel8:7.6",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -466,7 +447,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -476,7 +457,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "database",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},
@@ -555,26 +536,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}-postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql13-for-sso76-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-x509-https.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-x509-https.json
@@ -54,7 +54,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -82,7 +82,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -109,8 +109,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -120,7 +120,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -129,7 +129,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -295,26 +295,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso76-openshift-rhel8:7.6",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
+++ b/assets/operator/ocp-ppc64le/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
@@ -55,7 +55,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -80,7 +80,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -108,7 +108,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -135,8 +135,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -146,7 +146,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -155,7 +155,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -345,31 +345,12 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "sso76-openshift-rhel8:7.6",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -379,7 +360,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -388,7 +369,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},
@@ -471,26 +452,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}-postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql13-for-sso76-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{

--- a/assets/operator/ocp-ppc64le/webserver/templates/jws57-openjdk11-tomcat9-ubi8-basic-s2i.json
+++ b/assets/operator/ocp-ppc64le/webserver/templates/jws57-openjdk11-tomcat9-ubi8-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -141,8 +141,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -152,7 +152,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -161,7 +161,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -196,25 +196,7 @@
 						],
 						"terminationGracePeriodSeconds": 60
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${APPLICATION_NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-ppc64le/webserver/templates/jws57-openjdk11-tomcat9-ubi8-https-s2i.json
+++ b/assets/operator/ocp-ppc64le/webserver/templates/jws57-openjdk11-tomcat9-ubi8-https-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -188,8 +188,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -199,7 +199,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -208,7 +208,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -281,25 +281,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${APPLICATION_NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/ocp-s390x/cakephp/templates/cakephp-mysql-example.json
+++ b/assets/operator/ocp-s390x/cakephp/templates/cakephp-mysql-example.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -308,8 +308,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/ocp-s390x/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -325,8 +325,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/dancer/templates/dancer-mysql-example.json
+++ b/assets/operator/ocp-s390x/dancer/templates/dancer-mysql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -281,8 +281,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/dancer/templates/dancer-mysql-persistent.json
+++ b/assets/operator/ocp-s390x/dancer/templates/dancer-mysql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -298,8 +298,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/django/templates/django-psql-example.json
+++ b/assets/operator/ocp-s390x/django/templates/django-psql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -285,8 +285,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/django/templates/django-psql-persistent.json
+++ b/assets/operator/ocp-s390x/django/templates/django-psql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -302,8 +302,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/eap/templates/eap-xp3-basic-s2i.json
+++ b/assets/operator/ocp-s390x/eap/templates/eap-xp3-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -65,7 +65,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -254,8 +254,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -265,7 +265,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -280,7 +280,7 @@
 							"com.redhat.component-version": "3.0",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q3",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/eap/templates/eap-xp4-basic-s2i.json
+++ b/assets/operator/ocp-s390x/eap/templates/eap-xp4-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -65,7 +65,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -254,8 +254,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -265,7 +265,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -275,7 +275,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"com.company": "Red_Hat",
-							"deploymentConfig": "${APPLICATION_NAME}",
+							"deployment": "${APPLICATION_NAME}",
 							"rht.comp": "EAP_XP",
 							"rht.comp_ver": "4.0",
 							"rht.prod_name": "Red_Hat_Runtimes",

--- a/assets/operator/ocp-s390x/eap/templates/eap74-basic-s2i.json
+++ b/assets/operator/ocp-s390x/eap/templates/eap74-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -65,7 +65,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -254,8 +254,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -265,7 +265,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -280,7 +280,7 @@
 							"com.redhat.component-version": "7.4",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q2",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/eap/templates/eap74-https-s2i.json
+++ b/assets/operator/ocp-s390x/eap/templates/eap74-https-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -89,7 +89,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -297,8 +297,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -308,7 +308,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -323,7 +323,7 @@
 							"com.redhat.component-version": "7.4",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q2",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/eap/templates/eap74-sso-s2i.json
+++ b/assets/operator/ocp-s390x/eap/templates/eap74-sso-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -89,7 +89,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -316,8 +316,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -327,7 +327,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -342,7 +342,7 @@
 							"com.redhat.component-version": "7.4",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q2",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/httpd/templates/httpd-example.json
+++ b/assets/operator/ocp-s390x/httpd/templates/httpd-example.json
@@ -122,8 +122,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",

--- a/assets/operator/ocp-s390x/java/templates/openjdk-web-basic-s2i.json
+++ b/assets/operator/ocp-s390x/java/templates/openjdk-web-basic-s2i.json
@@ -42,7 +42,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -135,8 +135,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -146,7 +146,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -155,7 +155,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/jenkins/templates/jenkins-ephemeral-monitored.json
+++ b/assets/operator/ocp-s390x/jenkins/templates/jenkins-ephemeral-monitored.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/jenkins/templates/jenkins-ephemeral.json
+++ b/assets/operator/ocp-s390x/jenkins/templates/jenkins-ephemeral.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/jenkins/templates/jenkins-persistent-monitored.json
+++ b/assets/operator/ocp-s390x/jenkins/templates/jenkins-persistent-monitored.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/jenkins/templates/jenkins-persistent.json
+++ b/assets/operator/ocp-s390x/jenkins/templates/jenkins-persistent.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/mariadb/templates/mariadb-ephemeral.json
+++ b/assets/operator/ocp-s390x/mariadb/templates/mariadb-ephemeral.json
@@ -58,8 +58,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/mariadb/templates/mariadb-persistent.json
+++ b/assets/operator/ocp-s390x/mariadb/templates/mariadb-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/mysql/templates/mysql-ephemeral.json
+++ b/assets/operator/ocp-s390x/mysql/templates/mysql-ephemeral.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/mysql/templates/mysql-persistent.json
+++ b/assets/operator/ocp-s390x/mysql/templates/mysql-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/nginx/templates/nginx-example.json
+++ b/assets/operator/ocp-s390x/nginx/templates/nginx-example.json
@@ -124,8 +124,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",

--- a/assets/operator/ocp-s390x/nodejs/templates/nodejs-postgresql-example.json
+++ b/assets/operator/ocp-s390x/nodejs/templates/nodejs-postgresql-example.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -285,8 +285,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/nodejs/templates/nodejs-postgresql-persistent.json
+++ b/assets/operator/ocp-s390x/nodejs/templates/nodejs-postgresql-persistent.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -302,8 +302,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/nodejs/templates/react-web-app-example.json
+++ b/assets/operator/ocp-s390x/nodejs/templates/react-web-app-example.json
@@ -87,8 +87,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"app": "${NAME}"

--- a/assets/operator/ocp-s390x/postgresql/templates/postgresql-ephemeral.json
+++ b/assets/operator/ocp-s390x/postgresql/templates/postgresql-ephemeral.json
@@ -64,8 +64,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/postgresql/templates/postgresql-persistent.json
+++ b/assets/operator/ocp-s390x/postgresql/templates/postgresql-persistent.json
@@ -81,8 +81,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/rails/templates/rails-pgsql-persistent.json
+++ b/assets/operator/ocp-s390x/rails/templates/rails-pgsql-persistent.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -341,8 +341,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/rails/templates/rails-postgresql-example.json
+++ b/assets/operator/ocp-s390x/rails/templates/rails-postgresql-example.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -324,8 +324,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-s390x/redis/templates/redis-ephemeral.json
+++ b/assets/operator/ocp-s390x/redis/templates/redis-ephemeral.json
@@ -60,8 +60,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/redis/templates/redis-persistent.json
+++ b/assets/operator/ocp-s390x/redis/templates/redis-persistent.json
@@ -77,8 +77,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-s390x/sso/templates/sso75-https.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso75-https.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -88,7 +88,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -136,8 +136,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -147,7 +147,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -156,7 +156,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/sso/templates/sso75-ocp4-x509-https.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso75-ocp4-x509-https.json
@@ -53,7 +53,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -80,7 +80,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -107,8 +107,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -118,7 +118,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -127,7 +127,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/sso/templates/sso75-ocp4-x509-postgresql-persistent.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso75-ocp4-x509-postgresql-persistent.json
@@ -54,7 +54,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -78,7 +78,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -105,7 +105,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -132,8 +132,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -143,7 +143,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -152,7 +152,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -354,8 +354,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -365,7 +365,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -374,7 +374,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-s390x/sso/templates/sso75-postgresql-persistent.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso75-postgresql-persistent.json
@@ -39,7 +39,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -64,7 +64,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -88,7 +88,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -114,7 +114,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -162,8 +162,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -173,7 +173,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -182,7 +182,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -432,8 +432,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -443,7 +443,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -452,7 +452,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-s390x/sso/templates/sso75-postgresql.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso75-postgresql.json
@@ -40,7 +40,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -66,7 +66,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -91,7 +91,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -117,7 +117,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -167,8 +167,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -179,7 +179,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -189,7 +189,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "server",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -439,8 +439,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -451,7 +451,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -461,7 +461,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "database",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-https.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-https.json
@@ -39,7 +39,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -64,7 +64,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -91,7 +91,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -150,7 +150,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -159,7 +159,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-postgresql-persistent.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-postgresql-persistent.json
@@ -40,7 +40,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -66,7 +66,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -91,7 +91,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -118,7 +118,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -166,8 +166,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -177,7 +177,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -186,7 +186,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -447,8 +447,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -458,7 +458,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -467,7 +467,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-postgresql.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-postgresql.json
@@ -41,7 +41,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -68,7 +68,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -94,7 +94,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -121,7 +121,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -171,8 +171,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -183,7 +183,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -193,7 +193,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "server",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -454,8 +454,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -466,7 +466,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -476,7 +476,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "database",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-x509-https.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-x509-https.json
@@ -54,7 +54,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -82,7 +82,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -109,8 +109,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -120,7 +120,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -129,7 +129,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
+++ b/assets/operator/ocp-s390x/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
@@ -55,7 +55,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -80,7 +80,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -108,7 +108,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -135,8 +135,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -146,7 +146,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -155,7 +155,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -368,8 +368,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -379,7 +379,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -388,7 +388,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-s390x/webserver/templates/jws57-openjdk11-tomcat9-ubi8-basic-s2i.json
+++ b/assets/operator/ocp-s390x/webserver/templates/jws57-openjdk11-tomcat9-ubi8-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -141,8 +141,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -152,7 +152,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -161,7 +161,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-s390x/webserver/templates/jws57-openjdk11-tomcat9-ubi8-https-s2i.json
+++ b/assets/operator/ocp-s390x/webserver/templates/jws57-openjdk11-tomcat9-ubi8-https-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -188,8 +188,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -199,7 +199,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -208,7 +208,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/cakephp/templates/cakephp-mysql-example.json
+++ b/assets/operator/ocp-x86_64/cakephp/templates/cakephp-mysql-example.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -308,8 +308,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/ocp-x86_64/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -325,8 +325,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/dancer/templates/dancer-mysql-example.json
+++ b/assets/operator/ocp-x86_64/dancer/templates/dancer-mysql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -281,8 +281,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/dancer/templates/dancer-mysql-persistent.json
+++ b/assets/operator/ocp-x86_64/dancer/templates/dancer-mysql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -298,8 +298,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/datagrid/templates/cache-service.json
+++ b/assets/operator/ocp-x86_64/datagrid/templates/cache-service.json
@@ -56,7 +56,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -87,7 +87,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -122,7 +122,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/datagrid/templates/datagrid-service.json
+++ b/assets/operator/ocp-x86_64/datagrid/templates/datagrid-service.json
@@ -56,7 +56,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -87,7 +87,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -122,7 +122,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/django/templates/django-psql-example.json
+++ b/assets/operator/ocp-x86_64/django/templates/django-psql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -285,8 +285,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/django/templates/django-psql-persistent.json
+++ b/assets/operator/ocp-x86_64/django/templates/django-psql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -302,8 +302,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/eap/templates/eap-xp3-basic-s2i.json
+++ b/assets/operator/ocp-x86_64/eap/templates/eap-xp3-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -65,7 +65,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -254,8 +254,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -265,7 +265,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -280,7 +280,7 @@
 							"com.redhat.component-version": "3.0",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q3",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/eap/templates/eap-xp4-basic-s2i.json
+++ b/assets/operator/ocp-x86_64/eap/templates/eap-xp4-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -65,7 +65,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -254,8 +254,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -265,7 +265,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -275,7 +275,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"com.company": "Red_Hat",
-							"deploymentConfig": "${APPLICATION_NAME}",
+							"deployment": "${APPLICATION_NAME}",
 							"rht.comp": "EAP_XP",
 							"rht.comp_ver": "4.0",
 							"rht.prod_name": "Red_Hat_Runtimes",

--- a/assets/operator/ocp-x86_64/eap/templates/eap74-basic-s2i.json
+++ b/assets/operator/ocp-x86_64/eap/templates/eap74-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -65,7 +65,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -254,8 +254,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -265,7 +265,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -280,7 +280,7 @@
 							"com.redhat.component-version": "7.4",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q2",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/eap/templates/eap74-https-s2i.json
+++ b/assets/operator/ocp-x86_64/eap/templates/eap74-https-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -89,7 +89,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -297,8 +297,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -308,7 +308,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -323,7 +323,7 @@
 							"com.redhat.component-version": "7.4",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q2",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/eap/templates/eap74-sso-s2i.json
+++ b/assets/operator/ocp-x86_64/eap/templates/eap74-sso-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -89,7 +89,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -316,8 +316,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -327,7 +327,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -342,7 +342,7 @@
 							"com.redhat.component-version": "7.4",
 							"com.redhat.product-name": "Red_Hat_Runtimes",
 							"com.redhat.product-version": "2021-Q2",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/fis/templates/s2i-fuse712-spring-boot-2-camel-rest-3scale.json
+++ b/assets/operator/ocp-x86_64/fis/templates/s2i-fuse712-spring-boot-2-camel-rest-3scale.json
@@ -182,8 +182,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"creationTimestamp": null,
 				"labels": {
@@ -200,7 +200,7 @@
 				"selector": {
 					"app": "${APP_NAME}",
 					"component": "${APP_NAME}",
-					"deploymentconfig": "${APP_NAME}",
+					"deployment": "${APP_NAME}",
 					"group": "quickstarts",
 					"provider": "s2i",
 					"version": "${APP_VERSION}"
@@ -212,7 +212,7 @@
 							"app": "${APP_NAME}",
 							"com.company": "Red_Hat",
 							"component": "${APP_NAME}",
-							"deploymentconfig": "${APP_NAME}",
+							"deployment": "${APP_NAME}",
 							"group": "quickstarts",
 							"provider": "s2i",
 							"rht.comp": "${APP_NAME}",

--- a/assets/operator/ocp-x86_64/fis/templates/s2i-fuse712-spring-boot-2-camel-xml.json
+++ b/assets/operator/ocp-x86_64/fis/templates/s2i-fuse712-spring-boot-2-camel-xml.json
@@ -130,8 +130,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"creationTimestamp": null,
 				"labels": {
@@ -148,7 +148,7 @@
 				"selector": {
 					"app": "${APP_NAME}",
 					"component": "${APP_NAME}",
-					"deploymentconfig": "${APP_NAME}",
+					"deployment": "${APP_NAME}",
 					"group": "quickstarts",
 					"provider": "s2i",
 					"version": "${APP_VERSION}"
@@ -160,7 +160,7 @@
 							"app": "${APP_NAME}",
 							"com.company": "Red_Hat",
 							"component": "${APP_NAME}",
-							"deploymentconfig": "${APP_NAME}",
+							"deployment": "${APP_NAME}",
 							"group": "quickstarts",
 							"provider": "s2i",
 							"rht.comp": "${APP_NAME}",

--- a/assets/operator/ocp-x86_64/fis/templates/s2i-fuse712-spring-boot-2-camel.json
+++ b/assets/operator/ocp-x86_64/fis/templates/s2i-fuse712-spring-boot-2-camel.json
@@ -130,8 +130,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"creationTimestamp": null,
 				"labels": {
@@ -148,7 +148,7 @@
 				"selector": {
 					"app": "${APP_NAME}",
 					"component": "${APP_NAME}",
-					"deploymentconfig": "${APP_NAME}",
+					"deployment": "${APP_NAME}",
 					"group": "quickstarts",
 					"provider": "s2i",
 					"version": "${APP_VERSION}"
@@ -160,7 +160,7 @@
 							"app": "${APP_NAME}",
 							"com.company": "Red_Hat",
 							"component": "${APP_NAME}",
-							"deploymentconfig": "${APP_NAME}",
+							"deployment": "${APP_NAME}",
 							"group": "quickstarts",
 							"provider": "s2i",
 							"rht.comp": "${APP_NAME}",

--- a/assets/operator/ocp-x86_64/httpd/templates/httpd-example.json
+++ b/assets/operator/ocp-x86_64/httpd/templates/httpd-example.json
@@ -122,8 +122,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",

--- a/assets/operator/ocp-x86_64/java/templates/openjdk-web-basic-s2i.json
+++ b/assets/operator/ocp-x86_64/java/templates/openjdk-web-basic-s2i.json
@@ -42,7 +42,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -135,8 +135,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -146,7 +146,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -155,7 +155,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/jenkins/templates/jenkins-ephemeral-monitored.json
+++ b/assets/operator/ocp-x86_64/jenkins/templates/jenkins-ephemeral-monitored.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/jenkins/templates/jenkins-ephemeral.json
+++ b/assets/operator/ocp-x86_64/jenkins/templates/jenkins-ephemeral.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/jenkins/templates/jenkins-persistent-monitored.json
+++ b/assets/operator/ocp-x86_64/jenkins/templates/jenkins-persistent-monitored.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/jenkins/templates/jenkins-persistent.json
+++ b/assets/operator/ocp-x86_64/jenkins/templates/jenkins-persistent.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/mariadb/templates/mariadb-ephemeral.json
+++ b/assets/operator/ocp-x86_64/mariadb/templates/mariadb-ephemeral.json
@@ -58,8 +58,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/mariadb/templates/mariadb-persistent.json
+++ b/assets/operator/ocp-x86_64/mariadb/templates/mariadb-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/mysql/templates/mysql-ephemeral.json
+++ b/assets/operator/ocp-x86_64/mysql/templates/mysql-ephemeral.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/mysql/templates/mysql-persistent.json
+++ b/assets/operator/ocp-x86_64/mysql/templates/mysql-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/nginx/templates/nginx-example.json
+++ b/assets/operator/ocp-x86_64/nginx/templates/nginx-example.json
@@ -124,8 +124,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",

--- a/assets/operator/ocp-x86_64/nodejs/templates/nodejs-postgresql-example.json
+++ b/assets/operator/ocp-x86_64/nodejs/templates/nodejs-postgresql-example.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -285,8 +285,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/nodejs/templates/nodejs-postgresql-persistent.json
+++ b/assets/operator/ocp-x86_64/nodejs/templates/nodejs-postgresql-persistent.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -302,8 +302,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/nodejs/templates/react-web-app-example.json
+++ b/assets/operator/ocp-x86_64/nodejs/templates/react-web-app-example.json
@@ -87,8 +87,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"app": "${NAME}"

--- a/assets/operator/ocp-x86_64/postgresql/templates/postgresql-ephemeral.json
+++ b/assets/operator/ocp-x86_64/postgresql/templates/postgresql-ephemeral.json
@@ -64,8 +64,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/postgresql/templates/postgresql-persistent.json
+++ b/assets/operator/ocp-x86_64/postgresql/templates/postgresql-persistent.json
@@ -81,8 +81,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/rails/templates/rails-pgsql-persistent.json
+++ b/assets/operator/ocp-x86_64/rails/templates/rails-pgsql-persistent.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -341,8 +341,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/rails/templates/rails-postgresql-example.json
+++ b/assets/operator/ocp-x86_64/rails/templates/rails-postgresql-example.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -324,8 +324,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/ocp-x86_64/redis/templates/redis-ephemeral.json
+++ b/assets/operator/ocp-x86_64/redis/templates/redis-ephemeral.json
@@ -60,8 +60,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/redis/templates/redis-persistent.json
+++ b/assets/operator/ocp-x86_64/redis/templates/redis-persistent.json
@@ -77,8 +77,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/ocp-x86_64/sso/templates/sso75-https.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso75-https.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -88,7 +88,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -136,8 +136,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -147,7 +147,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -156,7 +156,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/sso/templates/sso75-ocp4-x509-https.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso75-ocp4-x509-https.json
@@ -53,7 +53,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -80,7 +80,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -107,8 +107,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -118,7 +118,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -127,7 +127,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/sso/templates/sso75-ocp4-x509-postgresql-persistent.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso75-ocp4-x509-postgresql-persistent.json
@@ -54,7 +54,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -78,7 +78,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -105,7 +105,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -132,8 +132,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -143,7 +143,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -152,7 +152,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -354,8 +354,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -365,7 +365,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -374,7 +374,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-x86_64/sso/templates/sso75-postgresql-persistent.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso75-postgresql-persistent.json
@@ -39,7 +39,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -64,7 +64,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -88,7 +88,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -114,7 +114,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -162,8 +162,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -173,7 +173,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -182,7 +182,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -432,8 +432,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -443,7 +443,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -452,7 +452,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-x86_64/sso/templates/sso75-postgresql.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso75-postgresql.json
@@ -40,7 +40,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -66,7 +66,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -91,7 +91,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -117,7 +117,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -167,8 +167,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -179,7 +179,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -189,7 +189,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "server",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -439,8 +439,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -451,7 +451,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -461,7 +461,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "database",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-https.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-https.json
@@ -39,7 +39,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -64,7 +64,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -91,7 +91,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -150,7 +150,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -159,7 +159,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-postgresql-persistent.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-postgresql-persistent.json
@@ -40,7 +40,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -66,7 +66,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -91,7 +91,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -118,7 +118,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -166,8 +166,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -177,7 +177,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -186,7 +186,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -447,8 +447,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -458,7 +458,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -467,7 +467,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-postgresql.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-postgresql.json
@@ -41,7 +41,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -68,7 +68,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -94,7 +94,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -121,7 +121,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -171,8 +171,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -183,7 +183,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -193,7 +193,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "server",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -454,8 +454,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}",
@@ -466,7 +466,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -476,7 +476,7 @@
 						"labels": {
 							"application": "${APPLICATION_NAME}",
 							"component": "database",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-x509-https.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-x509-https.json
@@ -54,7 +54,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -82,7 +82,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -109,8 +109,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -120,7 +120,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -129,7 +129,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
+++ b/assets/operator/ocp-x86_64/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
@@ -55,7 +55,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -80,7 +80,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -108,7 +108,7 @@
 				],
 				"publishNotReadyAddresses": true,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -135,8 +135,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -146,7 +146,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -155,7 +155,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},
@@ -368,8 +368,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -379,7 +379,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deployment": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -388,7 +388,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deployment": "${APPLICATION_NAME}-postgresql"
 						},
 						"name": "${APPLICATION_NAME}-postgresql"
 					},

--- a/assets/operator/ocp-x86_64/webserver/templates/jws57-openjdk11-tomcat9-ubi8-basic-s2i.json
+++ b/assets/operator/ocp-x86_64/webserver/templates/jws57-openjdk11-tomcat9-ubi8-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -141,8 +141,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -152,7 +152,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -161,7 +161,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/webserver/templates/jws57-openjdk11-tomcat9-ubi8-https-s2i.json
+++ b/assets/operator/ocp-x86_64/webserver/templates/jws57-openjdk11-tomcat9-ubi8-https-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -188,8 +188,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -199,7 +199,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -208,7 +208,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/webserver/templates/jws57-openjdk8-tomcat9-ubi8-basic-s2i.json
+++ b/assets/operator/ocp-x86_64/webserver/templates/jws57-openjdk8-tomcat9-ubi8-basic-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -141,8 +141,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -152,7 +152,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -161,7 +161,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/ocp-x86_64/webserver/templates/jws57-openjdk8-tomcat9-ubi8-https-s2i.json
+++ b/assets/operator/ocp-x86_64/webserver/templates/jws57-openjdk8-tomcat9-ubi8-https-s2i.json
@@ -38,7 +38,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -62,7 +62,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -188,8 +188,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -199,7 +199,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -208,7 +208,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-example.json
+++ b/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-example.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -308,8 +308,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-persistent.json
@@ -139,8 +139,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -325,8 +325,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-example.json
+++ b/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -281,8 +281,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-persistent.json
+++ b/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -298,8 +298,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/django/templates/django-psql-example.json
+++ b/assets/operator/okd-x86_64/django/templates/django-psql-example.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -285,8 +285,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/django/templates/django-psql-persistent.json
+++ b/assets/operator/okd-x86_64/django/templates/django-psql-persistent.json
@@ -138,8 +138,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -302,8 +302,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/httpd/templates/httpd-example.json
+++ b/assets/operator/okd-x86_64/httpd/templates/httpd-example.json
@@ -122,8 +122,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",

--- a/assets/operator/okd-x86_64/java/templates/openjdk-web-basic-s2i.json
+++ b/assets/operator/okd-x86_64/java/templates/openjdk-web-basic-s2i.json
@@ -42,7 +42,7 @@
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -135,8 +135,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -146,7 +146,7 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
+					"deployment": "${APPLICATION_NAME}"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -155,7 +155,7 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}"
+							"deployment": "${APPLICATION_NAME}"
 						},
 						"name": "${APPLICATION_NAME}"
 					},

--- a/assets/operator/okd-x86_64/jenkins/templates/jenkins-ephemeral-monitored.json
+++ b/assets/operator/okd-x86_64/jenkins/templates/jenkins-ephemeral-monitored.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/jenkins/templates/jenkins-ephemeral.json
+++ b/assets/operator/okd-x86_64/jenkins/templates/jenkins-ephemeral.json
@@ -49,8 +49,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/jenkins/templates/jenkins-persistent-monitored.json
+++ b/assets/operator/okd-x86_64/jenkins/templates/jenkins-persistent-monitored.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/jenkins/templates/jenkins-persistent.json
+++ b/assets/operator/okd-x86_64/jenkins/templates/jenkins-persistent.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/mariadb/templates/mariadb-ephemeral.json
+++ b/assets/operator/okd-x86_64/mariadb/templates/mariadb-ephemeral.json
@@ -58,8 +58,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/mariadb/templates/mariadb-persistent.json
+++ b/assets/operator/okd-x86_64/mariadb/templates/mariadb-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/mysql/templates/mysql-ephemeral.json
+++ b/assets/operator/okd-x86_64/mysql/templates/mysql-ephemeral.json
@@ -66,8 +66,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/mysql/templates/mysql-persistent.json
+++ b/assets/operator/okd-x86_64/mysql/templates/mysql-persistent.json
@@ -75,8 +75,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/nginx/templates/nginx-example.json
+++ b/assets/operator/okd-x86_64/nginx/templates/nginx-example.json
@@ -124,8 +124,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",

--- a/assets/operator/okd-x86_64/nodejs/templates/nodejs-postgresql-example.json
+++ b/assets/operator/okd-x86_64/nodejs/templates/nodejs-postgresql-example.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -285,8 +285,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/nodejs/templates/nodejs-postgresql-persistent.json
+++ b/assets/operator/okd-x86_64/nodejs/templates/nodejs-postgresql-persistent.json
@@ -142,8 +142,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -302,8 +302,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/nodejs/templates/react-web-app-example.json
+++ b/assets/operator/okd-x86_64/nodejs/templates/react-web-app-example.json
@@ -87,8 +87,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"labels": {
 					"app": "${NAME}"

--- a/assets/operator/okd-x86_64/postgresql/templates/postgresql-ephemeral.json
+++ b/assets/operator/okd-x86_64/postgresql/templates/postgresql-ephemeral.json
@@ -64,8 +64,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/postgresql/templates/postgresql-persistent.json
+++ b/assets/operator/okd-x86_64/postgresql/templates/postgresql-persistent.json
@@ -81,8 +81,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/rails/templates/rails-pgsql-persistent.json
+++ b/assets/operator/okd-x86_64/rails/templates/rails-pgsql-persistent.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -341,8 +341,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/rails/templates/rails-postgresql-example.json
+++ b/assets/operator/okd-x86_64/rails/templates/rails-postgresql-example.json
@@ -140,8 +140,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
@@ -324,8 +324,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",

--- a/assets/operator/okd-x86_64/redis/templates/redis-ephemeral.json
+++ b/assets/operator/okd-x86_64/redis/templates/redis-ephemeral.json
@@ -60,8 +60,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"

--- a/assets/operator/okd-x86_64/redis/templates/redis-persistent.json
+++ b/assets/operator/okd-x86_64/redis/templates/redis-persistent.json
@@ -77,8 +77,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"template.alpha.openshift.io/wait-for-ready": "true"


### PR DESCRIPTION
This operator suggests application examples in DeploymentConfig format. On the other hand, `DeploymentConfig` is deprecated and using `Deployment` is suggested instead.

This PR migrates from `DeploymentConfig` to `Deployment`. Since Deployment does not support `Triggers` field(thus, this functionality is also deprecated), this PR also removes this field from Deployment resources.