### PR TITLE
Use latest tag for network-tools imagestream

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -184,4 +184,4 @@ spec:
       importMode: PreserveOriginal
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-network-tools:4.13
+      name: quay.io/openshift/origin-network-tools:latest

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -45,4 +45,4 @@ spec:
   - name: network-tools
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-network-tools:4.13
+      name: quay.io/openshift/origin-network-tools:latest


### PR DESCRIPTION
4.13 doesn't look right at this point
added here https://github.com/openshift/cluster-samples-operator/pull/495