### PR TITLE
SO-119: Fix mariadb import url in OKD

### DIFF
--- a/assets/operator/okd-x86_64/mariadb/imagestreams/mariadb-centos.json
+++ b/assets/operator/okd-x86_64/mariadb/imagestreams/mariadb-centos.json
@@ -44,7 +44,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay./fedora/mariadb-105:latest"
+					"name": "quay.io/fedora/mariadb-105:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -64,7 +64,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay./sclorg/mariadb-105-c9s:latest"
+					"name": "quay.io/sclorg/mariadb-105-c9s:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -84,7 +84,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay./sclorg/mariadb-105-c8s:latest"
+					"name": "quay.io/sclorg/mariadb-105-c8s:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -124,7 +124,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay./sclorg/mariadb-105-c9s:latest"
+					"name": "quay.io/sclorg/mariadb-105-c9s:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -144,7 +144,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay./fedora/mariadb-103:latest"
+					"name": "quay.io/fedora/mariadb-103:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -164,7 +164,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay./sclorg/mariadb-103-c8s:latest"
+					"name": "quay.io/sclorg/mariadb-103-c8s:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -204,7 +204,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay./sclorg/mariadb-103-c8s:latest"
+					"name": "quay.io/sclorg/mariadb-103-c8s:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/okd-x86_64/ruby/imagestreams/ruby-centos.json
+++ b/assets/operator/okd-x86_64/ruby/imagestreams/ruby-centos.json
@@ -92,7 +92,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/ruby-1:latest"
+					"name": "registry.access.redhat.com/ubi8/ruby-31:latest"
 				},
 				"generation": null,
 				"importPolicy": {},


### PR DESCRIPTION
OKD tests are currently broken due to imagestream samples introduced in the recent sync containing invalid image import URLs.
This PR contains changes from:
- https://github.com/sclorg/mariadb-container/pull/220
- https://github.com/sclorg/s2i-ruby-container/pull/509