### PR TITLE
OCPBUGS-26992: Align builder and base for Dockerfile.okd with Dockerfile

### DIFF
--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-samples-operator
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.14
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
 COPY --from=builder /go/src/github.com/openshift/cluster-samples-operator/cluster-samples-operator /usr/bin/
 RUN ln -f /usr/bin/cluster-samples-operator /usr/bin/cluster-samples-operator-watch
 COPY manifests/image-references manifests/0* /manifests/


### PR DESCRIPTION
Hi team, 
OKD-SCOS for release 4.16 isn't building. Please help us update what is needed. 
Thank you