### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/manifests/06-operator-ibm-cloud-managed.yaml
+++ b/manifests/06-operator-ibm-cloud-managed.yaml
@@ -46,6 +46,7 @@ spec:
           capabilities:
             drop:
             - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/secrets
           name: samples-operator-tls
@@ -69,6 +70,7 @@ spec:
           capabilities:
             drop:
             - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true

--- a/manifests/06-operator.yaml
+++ b/manifests/06-operator.yaml
@@ -61,6 +61,7 @@ spec:
             drop:
             - ALL
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: samples-operator-tls
           mountPath: /etc/secrets
@@ -84,6 +85,7 @@ spec:
         - --termination-grace-period=30s
         - --files=/etc/secrets/tls.crt,/etc/secrets/tls.key
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.