### PR TITLE
WRKLDS-1015: tolerate node-role.kubernetes.io/control-plane:NoExecute 

### DIFF
--- a/manifests/06-operator-ibm-cloud-managed.yaml
+++ b/manifests/06-operator-ibm-cloud-managed.yaml
@@ -84,6 +84,9 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       - effect: NoExecute
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoExecute
         key: node.kubernetes.io/unreachable
         operator: Exists
         tolerationSeconds: 120

--- a/manifests/06-operator.yaml
+++ b/manifests/06-operator.yaml
@@ -32,6 +32,9 @@ spec:
       - key: node-role.kubernetes.io/master  # Just tolerate NoSchedule taint on master node. If there are other conditions like disk-pressure etc, let's not schedule the control-plane pods onto that node.
         operator: Exists
         effect: "NoSchedule"
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: "NoExecute"
       - key: "node.kubernetes.io/unreachable"
         operator: "Exists"
         effect: "NoExecute"


### PR DESCRIPTION
Required to be able to advise customers to follow workflow described in https://github.com/openshift/enhancements/pull/1583. If they want to taint control-plane nodes to avoid any other thing to run there (while enforcing it further with validating admission policies), control plane workloads need to tolerate that taint. 