### PR TITLE
AGENT-863: add a new image stream manifest for the fips capable installer

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -59,6 +59,24 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
   namespace: openshift
+  name: installer-fips
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  tags:
+  - name: latest
+    importPolicy:
+      scheduled: true
+      importMode: PreserveOriginal
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-baremetal-installer:4.16
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
   name: installer-artifacts
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"


### PR DESCRIPTION
This patch is required to retrieve the baremetal installer image by the day2 add node script (see https://github.com/openshift/installer/pull/8242)