### PR TITLE
OCPBUGS-29569: Apply hypershift cluster-profile for ibm-cloud-managed

### DIFF
--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""

--- a/manifests/010-prometheus-rules.yaml
+++ b/manifests/010-prometheus-rules.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: openshift-cluster-samples-operator
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:

--- a/manifests/02-sa.yaml
+++ b/manifests/02-sa.yaml
@@ -6,5 +6,6 @@ metadata:
   namespace: openshift-cluster-samples-operator
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/manifests/03-rbac-imageconfig-role-binding.yaml
+++ b/manifests/03-rbac-imageconfig-role-binding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cluster-samples-operator-imageconfig-reader
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 subjects:

--- a/manifests/03-rbac-imageconfig-role.yaml
+++ b/manifests/03-rbac-imageconfig-role.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cluster-samples-operator-imageconfig-reader
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:

--- a/manifests/03-rbac-proxies-role-binding.yaml
+++ b/manifests/03-rbac-proxies-role-binding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cluster-samples-operator-proxy-reader
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 subjects:

--- a/manifests/03-rbac-proxies-role.yaml
+++ b/manifests/03-rbac-proxies-role.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cluster-samples-operator-proxy-reader
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:

--- a/manifests/03-rbac.yaml
+++ b/manifests/03-rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cluster-samples-operator
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
@@ -38,6 +39,7 @@ metadata:
   name: cluster-samples-operator
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
@@ -66,6 +68,7 @@ metadata:
   name: system:openshift:cluster-samples-operator:cluster-reader
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
@@ -88,6 +91,7 @@ metadata:
   namespace: openshift-cluster-samples-operator
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 subjects:
@@ -106,6 +110,7 @@ metadata:
   name: cluster-samples-operator
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 subjects:

--- a/manifests/04-openshift-rbac.yaml
+++ b/manifests/04-openshift-rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 subjects:

--- a/manifests/05-kube-system-rbac.yaml
+++ b/manifests/05-kube-system-rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-config
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
@@ -26,6 +27,7 @@ metadata:
   namespace: openshift-config
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 subjects:

--- a/manifests/06-metricsservice.yaml
+++ b/manifests/06-metricsservice.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.beta.openshift.io/serving-cert-secret-name: samples-operator-tls

--- a/manifests/06-operator-ibm-cloud-managed.yaml
+++ b/manifests/06-operator-ibm-cloud-managed.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
   name: cluster-samples-operator
   namespace: openshift-cluster-samples-operator

--- a/manifests/06-servicemonitor.yaml
+++ b/manifests/06-servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-cluster-samples-operator
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:

--- a/manifests/07-clusteroperator.yaml
+++ b/manifests/07-clusteroperator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-samples
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec: {}

--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: openshift
   name: cli
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -25,6 +26,7 @@ metadata:
   namespace: openshift
   name: cli-artifacts
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -43,6 +45,7 @@ metadata:
   namespace: openshift
   name: installer
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -61,6 +64,7 @@ metadata:
   namespace: openshift
   name: installer-artifacts
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -79,6 +83,7 @@ metadata:
   namespace: openshift
   name: tests
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -97,6 +102,7 @@ metadata:
   namespace: openshift
   name: tools
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -115,6 +121,7 @@ metadata:
   namespace: openshift
   name: must-gather
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -133,6 +140,7 @@ metadata:
   namespace: openshift
   name: oauth-proxy
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -154,6 +162,7 @@ metadata:
   name: hello-openshift
   annotations:
     release.openshift.io/delete: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -174,6 +183,7 @@ metadata:
   namespace: openshift
   name: network-tools
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:

--- a/manifests/09-servicemonitor-rbac.yaml
+++ b/manifests/09-servicemonitor-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-cluster-samples-operator
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
@@ -27,6 +28,7 @@ metadata:
   namespace: openshift-cluster-samples-operator
   annotations:
     capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:

--- a/profile-patches/hypershift/06-operator.yaml-patch
+++ b/profile-patches/hypershift/06-operator.yaml-patch
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/annotations/include.release.openshift.io~1hypershift
+  value: "true"


### PR DESCRIPTION
Since HyperShift / Hosted Control Plane have adopted `include.release.openshift.io/ibm-cloud-managed`, to tailor the resources of clusters running in the ROKS IBM environment, the `include.release.openshift.io/hypershift` addition will allow Hypershift to express different profile choices than ROKS