### PR TITLE
NO-ISSUE: Only pick up the changes from the supported imagestreams and templates in library-sync.sh.

### DIFF
--- a/library-sync.sh
+++ b/library-sync.sh
@@ -53,3 +53,23 @@ git add operator
 rm t.tar
 rm -rf library-master
 
+SUPPORTED="ruby python nodejs perl php httpd nginx eap java webserver dotnet golang"
+function reset_unsupported() {
+  for d in $(ls); do
+    if [[ "${SUPPORTED}" != *"${d}"* ]]; then
+      git reset HEAD -- "${d}"
+      # remove any changes from the working tree in this directory that reset left behind
+      git stash -u -- "${d}"
+      git stash drop
+    fi
+  done
+}
+
+ARCHS="ocp-x86_64 ocp-aarch64 ocp-ppc64le ocp-s390x okd-x86_64"
+pushd operator
+for arch in $ARCHS; do
+  pushd "${arch}"
+  reset_unsupported
+  popd # $arch
+done
+popd # operator


### PR DESCRIPTION
This updates the `library-sync.sh` script to only update the imagestreams and templates of the supported samples.

This should ease the release process so that we (or any future maintainer) doesn't have to remember to manually go through the changes brought in from openshift and remove any changes to the unsupported samples.