### PR TITLE
OCPBUGS-38994: Fix library-sync.sh to handle renames in unsupported samples

### DIFF
--- a/library-sync.sh
+++ b/library-sync.sh
@@ -57,9 +57,9 @@ SUPPORTED="ruby python nodejs perl php httpd nginx eap java webserver dotnet gol
 function reset_unsupported() {
   for d in $(ls); do
     if [[ "${SUPPORTED}" != *"${d}"* ]]; then
-      git reset HEAD -- "${d}"
-      # remove any changes from the working tree in this directory that reset left behind
-      git stash -u -- "${d}"
+      git checkout HEAD -- "${d}"
+      # remove any changes from the working tree in this directory that checkout left behind
+      git stash -a -- "${d}"
       git stash drop
     fi
   done


### PR DESCRIPTION
Improve the handling of changes in the unsupported samples so that no traces are left behind even when files were renamed or moved to a different location.