### PR TITLE
OKD-225: update okd dockerfile builder and base images

### DIFF
--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-samples-operator
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.18
 COPY --from=builder /go/src/github.com/openshift/cluster-samples-operator/cluster-samples-operator /usr/bin/
 RUN ln -f /usr/bin/cluster-samples-operator /usr/bin/cluster-samples-operator-watch
 COPY manifests/image-references manifests/0* /manifests/


### PR DESCRIPTION
base and builder images need to be updated to avoid build failures.