### PR TITLE
Remove the CentOS 7 versions of containers

### DIFF
--- a/assets/operator/okd-x86_64/mariadb/imagestreams/mariadb-centos.json
+++ b/assets/operator/okd-x86_64/mariadb/imagestreams/mariadb-centos.json
@@ -93,26 +93,6 @@
 				}
 			},
 			{
-				"name": "10.5-el7",
-				"annotations": {
-					"description": "Provides a MariaDB 10.5 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.5/README.md.",
-					"iconClass": "icon-mariadb",
-					"openshift.io/display-name": "MariaDB 10.5 (CentOS 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"tags": "database,mariadb",
-					"version": "10.5"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "quay.io/centos7/mariadb-105-centos7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "10.5",
 				"annotations": {
 					"description": "Provides a MariaDB 10.5 database on CentOS 9 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
@@ -165,26 +145,6 @@
 				"from": {
 					"kind": "DockerImage",
 					"name": "quay.io/sclorg/mariadb-103-c8s:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "10.3-el7",
-				"annotations": {
-					"description": "Provides a MariaDB 10.3 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
-					"iconClass": "icon-mariadb",
-					"openshift.io/display-name": "MariaDB 10.3 (CentOS 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"tags": "database,mariadb",
-					"version": "10.3"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "quay.io/centos7/mariadb-103-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/okd-x86_64/mysql/imagestreams/mysql-centos.json
+++ b/assets/operator/okd-x86_64/mysql/imagestreams/mysql-centos.json
@@ -93,26 +93,6 @@
 				}
 			},
 			{
-				"name": "8.0-el7",
-				"annotations": {
-					"description": "Provides a MySQL 8.0 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",
-					"iconClass": "icon-mysql-database",
-					"openshift.io/display-name": "MySQL 8.0 (CentOS 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"tags": "mysql",
-					"version": "8.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "quay.io/centos7/mysql-80-centos7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "8.0",
 				"annotations": {
 					"description": "Provides a MySQL 8.0 database on CentOS 9 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/README.md.",

--- a/assets/operator/okd-x86_64/perl/imagestreams/perl-centos.json
+++ b/assets/operator/okd-x86_64/perl/imagestreams/perl-centos.json
@@ -79,50 +79,6 @@
 				}
 			},
 			{
-				"name": "5.30-el7",
-				"annotations": {
-					"description": "Build and run Perl 5.30 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
-					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.30 (CentOS 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.30,perl",
-					"tags": "builder,perl",
-					"version": "5.30"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "quay.io/centos7/perl-530-centos7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "5.30",
-				"annotations": {
-					"description": "Build and run Perl 5.30 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
-					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.30",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.30,perl",
-					"tags": "builder,perl,hidden",
-					"version": "5.30"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "quay.io/centos7/perl-530-centos7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "5.26-ubi8",
 				"annotations": {
 					"description": "Build and run Perl 5.26 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26-mod_fcgid/README.md.",

--- a/assets/operator/okd-x86_64/redis/imagestreams/redis-centos.json
+++ b/assets/operator/okd-x86_64/redis/imagestreams/redis-centos.json
@@ -24,7 +24,7 @@
 				},
 				"from": {
 					"kind": "ImageStreamTag",
-					"name": "6-el7"
+					"name": "6-el9"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -33,18 +33,18 @@
 				}
 			},
 			{
-				"name": "6-el7",
+				"name": "6-el9",
 				"annotations": {
 					"description": "Provides a Redis 6 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/redis-container/tree/master/6/README.md.",
 					"iconClass": "icon-redis",
-					"openshift.io/display-name": "Redis 6 (CentOS 7)",
+					"openshift.io/display-name": "Redis 6 (CentOS 9 Stream)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"tags": "redis",
 					"version": "6"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay.io/centos7/redis-6-centos7:latest"
+					"name": "quay.io/repository/sclorg/redis-6-c9s:latest"
 				},
 				"generation": null,
 				"importPolicy": {},


### PR DESCRIPTION
All of the :latest links for CentOS 7 images have been removed. This change removes the CentOS 7 image references for all images, all of them but redis already have other options available. For redis use I moved to the CentOS 9 Stream verson of redis 6.  We want this change to go to all branches down to 4.16