### PR TITLE
OKD-225: Add back mysql samples

### DIFF
--- a/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-example.json
+++ b/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-example.json
@@ -139,11 +139,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -151,7 +152,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
 					"recreateParams": {
@@ -264,25 +267,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"cakephp-mysql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -308,11 +293,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -320,7 +306,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -409,26 +397,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-persistent.json
@@ -12,8 +12,7 @@
 			"openshift.io/long-description": "This template defines resources needed to develop a CakePHP application, including a build configuration, application deployment configuration, and database deployment configuration.",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"openshift.io/support-url": "https://access.redhat.com",
-			"tags": "quickstart,php,cakephp",
-			"template.openshift.io/bindable": "false"
+			"tags": "quickstart,php,cakephp"
 		}
 	},
 	"message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/cakephp-ex/blob/master/README.md.",
@@ -58,6 +57,9 @@
 			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-uri": "http://{.spec.host}{.spec.path}"
+				},
 				"name": "${NAME}"
 			},
 			"spec": {
@@ -139,11 +141,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"},{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.initContainers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -151,20 +154,11 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
-					"recreateParams": {
-						"pre": {
-							"execNewPod": {
-								"command": [
-									"./migrate-database.sh"
-								],
-								"containerName": "cakephp-mysql-persistent"
-							},
-							"failurePolicy": "Retry"
-						}
-					},
 					"type": "Recreate"
 				},
 				"template": {
@@ -241,7 +235,7 @@
 									"periodSeconds": 60,
 									"timeoutSeconds": 3
 								},
-								"name": "cakephp-mysql-persistent",
+								"name": "${NAME}",
 								"ports": [
 									{
 										"containerPort": 8080
@@ -262,27 +256,72 @@
 									}
 								}
 							}
+						],
+						"initContainers": [
+							{
+								"command": [
+									"./migrate-database.sh"
+								],
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "DATABASE_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "DATABASE_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "CAKEPHP_SECRET_TOKEN",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "cakephp-secret-token",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "CAKEPHP_SECURITY_SALT",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "cakephp-security-salt",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "DATABASE_NAME",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "DATABASE_ENGINE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "APPLICATION_DOMAIN",
+										"value": "${APPLICATION_DOMAIN}"
+									}
+								],
+								"image": " ",
+								"name": "cakephp-init-container"
+							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"cakephp-mysql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -325,11 +364,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -337,7 +377,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -428,26 +470,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-example.json
+++ b/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-example.json
@@ -138,11 +138,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -150,7 +151,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -237,25 +240,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"dancer-mysql-example"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -281,8 +266,8 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
@@ -382,26 +367,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:8.0-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],

--- a/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-persistent.json
+++ b/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-persistent.json
@@ -138,11 +138,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -150,7 +151,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -237,25 +240,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"dancer-mysql-persistent"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -298,11 +283,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -310,7 +296,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -401,26 +389,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:8.0-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],
@@ -444,6 +413,13 @@
 			"displayName": "Version of Perl Image",
 			"description": "Version of Perl image to be used (5.30-el7, 5.30-ubi8, or latest).",
 			"value": "5.30-ubi8",
+			"required": true
+		},
+		{
+			"name": "MYSQL_VERSION",
+			"displayName": "Version of MySQL Image",
+			"description": "Version of MySQL image to be used (8.0-el8, 8.0-el9, or latest).",
+			"value": "8.0-el8",
 			"required": true
 		},
 		{

--- a/assets/operator/okd-x86_64/mariadb/imagestreams/mariadb-centos.json
+++ b/assets/operator/okd-x86_64/mariadb/imagestreams/mariadb-centos.json
@@ -1,0 +1,81 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "image.openshift.io/v1",
+	"metadata": {
+		"name": "mariadb",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "MariaDB"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "10.5-el9",
+				"annotations": {
+					"description": "Provides a MariaDB 10.5 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.5/README.md.",
+					"iconClass": "icon-mariadb",
+					"openshift.io/display-name": "MariaDB 10.5 (CentOS Stream 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "database,mariadb",
+					"version": "10.5"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "quay.io/sclorg/mariadb-105-c9s:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "10.11-el9",
+				"annotations": {
+					"description": "Provides a MariaDB 10.11 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.11/README.md.",
+					"iconClass": "icon-mariadb",
+					"openshift.io/display-name": "MariaDB 10.11 (CentOS Stream 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "database,mariadb",
+					"version": "10.11"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "quay.io/sclorg/mariadb-1011-c9s:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Provides a MariaDB 10.11 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.11/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-mariadb",
+					"openshift.io/display-name": "MariaDB 10.11 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "database,mariadb",
+					"version": "10.11"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "10.11-el9"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/assets/operator/okd-x86_64/mariadb/templates/mariadb-ephemeral.json
+++ b/assets/operator/okd-x86_64/mariadb/templates/mariadb-ephemeral.json
@@ -1,0 +1,249 @@
+{
+	"kind": "Template",
+	"apiVersion": "template.openshift.io/v1",
+	"metadata": {
+		"name": "mariadb-ephemeral",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "MariaDB database service, without persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/blob/master/10.3/root/usr/share/container-scripts/mysql/README.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
+			"iconClass": "icon-mariadb",
+			"openshift.io/display-name": "MariaDB (Ephemeral)",
+			"openshift.io/documentation-url": "https://github.com/sclorg/mariadb-container/blob/master/10.3/root/usr/share/container-scripts/mysql/README.md",
+			"openshift.io/long-description": "This template provides a standalone MariaDB server with a database created.  The database is not stored on persistent storage, so any restart of the service will result in all data being lost.  The database name, username, and password are chosen via parameters when provisioning this service.",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"openshift.io/support-url": "https://access.redhat.com",
+			"tags": "database,mariadb"
+		}
+	},
+	"message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${MYSQL_USER}\n       Password: ${MYSQL_PASSWORD}\n  Database Name: ${MYSQL_DATABASE}\n Connection URL: mysql://${DATABASE_SERVICE_NAME}:3306/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/blob/master/10.3/root/usr/share/container-scripts/mysql/README.md.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Secret",
+			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-database_name": "{.data['database-name']}",
+					"template.openshift.io/expose-password": "{.data['database-password']}",
+					"template.openshift.io/expose-root_password": "{.data['database-root-password']}",
+					"template.openshift.io/expose-username": "{.data['database-user']}"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"stringData": {
+				"database-name": "${MYSQL_DATABASE}",
+				"database-password": "${MYSQL_PASSWORD}",
+				"database-root-password": "${MYSQL_ROOT_PASSWORD}",
+				"database-user": "${MYSQL_USER}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-uri": "mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\"mariadb\")].port}"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"name": "mariadb",
+						"port": 3306
+					}
+				],
+				"selector": {
+					"name": "${DATABASE_SERVICE_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
+			"metadata": {
+				"annotations": {
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"template.alpha.openshift.io/wait-for-ready": "true"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"name": "${DATABASE_SERVICE_NAME}"
+						}
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "MYSQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_ROOT_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-root-password",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_DATABASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-name",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									}
+								],
+								"image": " ",
+								"imagePullPolicy": "IfNotPresent",
+								"livenessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"
+										]
+									},
+									"initialDelaySeconds": 30,
+									"timeoutSeconds": 1
+								},
+								"name": "mariadb",
+								"ports": [
+									{
+										"containerPort": 3306
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"
+										]
+									},
+									"initialDelaySeconds": 5,
+									"timeoutSeconds": 1
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/mysql/data",
+										"name": "${DATABASE_SERVICE_NAME}-data"
+									}
+								]
+							}
+						],
+						"volumes": [
+							{
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${DATABASE_SERVICE_NAME}-data"
+							}
+						]
+					}
+				}
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Memory Limit",
+			"description": "Maximum amount of memory the container can use.",
+			"value": "512Mi",
+			"required": true
+		},
+		{
+			"name": "NAMESPACE",
+			"displayName": "Namespace",
+			"description": "The OpenShift Namespace where the ImageStream resides.",
+			"value": "openshift"
+		},
+		{
+			"name": "DATABASE_SERVICE_NAME",
+			"displayName": "Database Service Name",
+			"description": "The name of the OpenShift Service exposed for the database.",
+			"value": "mariadb",
+			"required": true
+		},
+		{
+			"name": "MYSQL_USER",
+			"displayName": "MariaDB Connection Username",
+			"description": "Username for MariaDB user that will be used for accessing the database.",
+			"generate": "expression",
+			"from": "user[A-Z0-9]{3}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_PASSWORD",
+			"displayName": "MariaDB Connection Password",
+			"description": "Password for the MariaDB connection user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_ROOT_PASSWORD",
+			"displayName": "MariaDB root Password",
+			"description": "Password for the MariaDB root user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_DATABASE",
+			"displayName": "MariaDB Database Name",
+			"description": "Name of the MariaDB database accessed.",
+			"value": "sampledb",
+			"required": true
+		},
+		{
+			"name": "MARIADB_VERSION",
+			"displayName": "Version of MariaDB Image",
+			"description": "Version of MariaDB image to be used (10.3-el7, 10.3-el8, or latest).",
+			"value": "10.3-el8",
+			"required": true
+		}
+	],
+	"labels": {
+		"app.openshift.io/runtime": "mariadb",
+		"template": "mariadb-ephemeral-template"
+	}
+}

--- a/assets/operator/okd-x86_64/mariadb/templates/mariadb-persistent.json
+++ b/assets/operator/okd-x86_64/mariadb/templates/mariadb-persistent.json
@@ -2,20 +2,20 @@
 	"kind": "Template",
 	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
-		"name": "postgresql-persistent",
+		"name": "mariadb-persistent",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "PostgreSQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.",
-			"iconClass": "icon-postgresql",
-			"openshift.io/display-name": "PostgreSQL",
-			"openshift.io/documentation-url": "https://docs.okd.io/latest/using_images/db_images/postgresql.html",
-			"openshift.io/long-description": "This template provides a standalone PostgreSQL server with a database created.  The database is stored on persistent storage.  The database name, username, and password are chosen via parameters when provisioning this service.",
+			"description": "MariaDB database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/blob/master/10.3/root/usr/share/container-scripts/mysql/README.md.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.",
+			"iconClass": "icon-mariadb",
+			"openshift.io/display-name": "MariaDB",
+			"openshift.io/documentation-url": "https://github.com/sclorg/mariadb-container/blob/master/10.3/root/usr/share/container-scripts/mysql/README.md",
+			"openshift.io/long-description": "This template provides a standalone MariaDB server with a database created.  The database is stored on persistent storage.  The database name, username, and password are chosen via parameters when provisioning this service.",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"openshift.io/support-url": "https://access.redhat.com",
-			"tags": "database,postgresql"
+			"tags": "database,mariadb"
 		}
 	},
-	"message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${POSTGRESQL_USER}\n       Password: ${POSTGRESQL_PASSWORD}\n  Database Name: ${POSTGRESQL_DATABASE}\n Connection URL: postgresql://${DATABASE_SERVICE_NAME}:5432/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.",
+	"message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${MYSQL_USER}\n       Password: ${MYSQL_PASSWORD}\n  Database Name: ${MYSQL_DATABASE}\n Connection URL: mysql://${DATABASE_SERVICE_NAME}:3306/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/blob/master/10.3/root/usr/share/container-scripts/mysql/README.md.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -24,14 +24,16 @@
 				"annotations": {
 					"template.openshift.io/expose-database_name": "{.data['database-name']}",
 					"template.openshift.io/expose-password": "{.data['database-password']}",
+					"template.openshift.io/expose-root_password": "{.data['database-root-password']}",
 					"template.openshift.io/expose-username": "{.data['database-user']}"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
 			},
 			"stringData": {
-				"database-name": "${POSTGRESQL_DATABASE}",
-				"database-password": "${POSTGRESQL_PASSWORD}",
-				"database-user": "${POSTGRESQL_USER}"
+				"database-name": "${MYSQL_DATABASE}",
+				"database-password": "${MYSQL_PASSWORD}",
+				"database-root-password": "${MYSQL_ROOT_PASSWORD}",
+				"database-user": "${MYSQL_USER}"
 			}
 		},
 		{
@@ -39,28 +41,20 @@
 			"kind": "Service",
 			"metadata": {
 				"annotations": {
-					"template.openshift.io/expose-uri": "postgres://{.spec.clusterIP}:{.spec.ports[?(.name==\"postgresql\")].port}"
+					"template.openshift.io/expose-uri": "mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\"mariadb\")].port}"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
 			},
 			"spec": {
 				"ports": [
 					{
-						"name": "postgresql",
-						"nodePort": 0,
-						"port": 5432,
-						"protocol": "TCP",
-						"targetPort": 5432
+						"name": "mariadb",
+						"port": 3306
 					}
 				],
 				"selector": {
 					"name": "${DATABASE_SERVICE_NAME}"
-				},
-				"sessionAffinity": "None",
-				"type": "ClusterIP"
-			},
-			"status": {
-				"loadBalancer": {}
+				}
 			}
 		},
 		{
@@ -85,7 +79,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -109,10 +103,9 @@
 					"spec": {
 						"containers": [
 							{
-								"capabilities": {},
 								"env": [
 									{
-										"name": "POSTGRESQL_USER",
+										"name": "MYSQL_USER",
 										"valueFrom": {
 											"secretKeyRef": {
 												"key": "database-user",
@@ -121,7 +114,7 @@
 										}
 									},
 									{
-										"name": "POSTGRESQL_PASSWORD",
+										"name": "MYSQL_PASSWORD",
 										"valueFrom": {
 											"secretKeyRef": {
 												"key": "database-password",
@@ -130,7 +123,16 @@
 										}
 									},
 									{
-										"name": "POSTGRESQL_DATABASE",
+										"name": "MYSQL_ROOT_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-root-password",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_DATABASE",
 										"valueFrom": {
 											"secretKeyRef": {
 												"key": "database-name",
@@ -144,24 +146,28 @@
 								"livenessProbe": {
 									"exec": {
 										"command": [
-											"/usr/libexec/check-container",
-											"--live"
+											"/bin/sh",
+											"-i",
+											"-c",
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"
 										]
 									},
-									"initialDelaySeconds": 120,
-									"timeoutSeconds": 10
+									"initialDelaySeconds": 30,
+									"timeoutSeconds": 1
 								},
-								"name": "postgresql",
+								"name": "mariadb",
 								"ports": [
 									{
-										"containerPort": 5432,
-										"protocol": "TCP"
+										"containerPort": 3306
 									}
 								],
 								"readinessProbe": {
 									"exec": {
 										"command": [
-											"/usr/libexec/check-container"
+											"/bin/sh",
+											"-i",
+											"-c",
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"
 										]
 									},
 									"initialDelaySeconds": 5,
@@ -172,21 +178,14 @@
 										"memory": "${MEMORY_LIMIT}"
 									}
 								},
-								"securityContext": {
-									"capabilities": {},
-									"privileged": false
-								},
-								"terminationMessagePath": "/dev/termination-log",
 								"volumeMounts": [
 									{
-										"mountPath": "/var/lib/pgsql/data",
+										"mountPath": "/var/lib/mysql/data",
 										"name": "${DATABASE_SERVICE_NAME}-data"
 									}
 								]
 							}
 						],
-						"dnsPolicy": "ClusterFirst",
-						"restartPolicy": "Always",
 						"volumes": [
 							{
 								"name": "${DATABASE_SERVICE_NAME}-data",
@@ -197,8 +196,7 @@
 						]
 					}
 				}
-			},
-			"status": {}
+			}
 		}
 	],
 	"parameters": [
@@ -219,30 +217,45 @@
 			"name": "DATABASE_SERVICE_NAME",
 			"displayName": "Database Service Name",
 			"description": "The name of the OpenShift Service exposed for the database.",
-			"value": "postgresql",
+			"value": "mariadb",
 			"required": true
 		},
 		{
-			"name": "POSTGRESQL_USER",
-			"displayName": "PostgreSQL Connection Username",
-			"description": "Username for PostgreSQL user that will be used for accessing the database.",
+			"name": "MYSQL_USER",
+			"displayName": "MariaDB Connection Username",
+			"description": "Username for MariaDB user that will be used for accessing the database.",
 			"generate": "expression",
 			"from": "user[A-Z0-9]{3}",
 			"required": true
 		},
 		{
-			"name": "POSTGRESQL_PASSWORD",
-			"displayName": "PostgreSQL Connection Password",
-			"description": "Password for the PostgreSQL connection user.",
+			"name": "MYSQL_PASSWORD",
+			"displayName": "MariaDB Connection Password",
+			"description": "Password for the MariaDB connection user.",
 			"generate": "expression",
 			"from": "[a-zA-Z0-9]{16}",
 			"required": true
 		},
 		{
-			"name": "POSTGRESQL_DATABASE",
-			"displayName": "PostgreSQL Database Name",
-			"description": "Name of the PostgreSQL database accessed.",
+			"name": "MYSQL_ROOT_PASSWORD",
+			"displayName": "MariaDB root Password",
+			"description": "Password for the MariaDB root user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_DATABASE",
+			"displayName": "MariaDB Database Name",
+			"description": "Name of the MariaDB database accessed.",
 			"value": "sampledb",
+			"required": true
+		},
+		{
+			"name": "MARIADB_VERSION",
+			"displayName": "Version of MariaDB Image",
+			"description": "Version of MariaDB image to be used (10.3-el7, 10.3-el8, or latest).",
+			"value": "10.3-el8",
 			"required": true
 		},
 		{
@@ -251,16 +264,10 @@
 			"description": "Volume space available for data, e.g. 512Mi, 2Gi.",
 			"value": "1Gi",
 			"required": true
-		},
-		{
-			"name": "POSTGRESQL_VERSION",
-			"displayName": "Version of PostgreSQL Image",
-			"description": "Version of PostgreSQL image to be used (13-el8, 15-el8, or latest).",
-			"value": "15-el8",
-			"required": true
 		}
 	],
 	"labels": {
-		"template": "postgresql-persistent-template"
+		"app.openshift.io/runtime": "mariadb",
+		"template": "mariadb-persistent-template"
 	}
 }

--- a/assets/operator/okd-x86_64/mysql/imagestreams/mysql-centos.json
+++ b/assets/operator/okd-x86_64/mysql/imagestreams/mysql-centos.json
@@ -1,0 +1,61 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "image.openshift.io/v1",
+	"metadata": {
+		"name": "mysql",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "MySQL"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "8.0-el9",
+				"annotations": {
+					"description": "Provides a MySQL 8.0 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/README.md.",
+					"iconClass": "icon-mysql",
+					"openshift.io/display-name": "MySQL 8.0 (CentOS Stream 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "database,mysql",
+					"version": "8.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "quay.io/sclorg/mysql-80-c9s:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Provides a MySQL 8.0 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-mysql",
+					"openshift.io/display-name": "MySQL 8.0 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "database,mysql",
+					"version": "8.0"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "8.0-el9"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/assets/operator/okd-x86_64/mysql/templates/mysql-ephemeral.json
+++ b/assets/operator/okd-x86_64/mysql/templates/mysql-ephemeral.json
@@ -1,0 +1,267 @@
+{
+	"kind": "Template",
+	"apiVersion": "template.openshift.io/v1",
+	"metadata": {
+		"name": "mysql-ephemeral",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "MySQL database service, without persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
+			"iconClass": "icon-mysql-database",
+			"openshift.io/display-name": "MySQL (Ephemeral)",
+			"openshift.io/documentation-url": "https://docs.okd.io/latest/using_images/db_images/mysql.html",
+			"openshift.io/long-description": "This template provides a standalone MySQL server with a database created.  The database is not stored on persistent storage, so any restart of the service will result in all data being lost.  The database name, username, and password are chosen via parameters when provisioning this service.",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"openshift.io/support-url": "https://access.redhat.com",
+			"tags": "database,mysql"
+		}
+	},
+	"message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${MYSQL_USER}\n       Password: ${MYSQL_PASSWORD}\n  Database Name: ${MYSQL_DATABASE}\n Connection URL: mysql://${DATABASE_SERVICE_NAME}:3306/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Secret",
+			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-database_name": "{.data['database-name']}",
+					"template.openshift.io/expose-password": "{.data['database-password']}",
+					"template.openshift.io/expose-root_password": "{.data['database-root-password']}",
+					"template.openshift.io/expose-username": "{.data['database-user']}"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"stringData": {
+				"database-name": "${MYSQL_DATABASE}",
+				"database-password": "${MYSQL_PASSWORD}",
+				"database-root-password": "${MYSQL_ROOT_PASSWORD}",
+				"database-user": "${MYSQL_USER}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-uri": "mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\"mysql\")].port}"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"name": "mysql",
+						"nodePort": 0,
+						"port": 3306,
+						"protocol": "TCP",
+						"targetPort": 3306
+					}
+				],
+				"selector": {
+					"name": "${DATABASE_SERVICE_NAME}"
+				},
+				"sessionAffinity": "None",
+				"type": "ClusterIP"
+			},
+			"status": {
+				"loadBalancer": {}
+			}
+		},
+		{
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
+			"metadata": {
+				"annotations": {
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"template.alpha.openshift.io/wait-for-ready": "true"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"name": "${DATABASE_SERVICE_NAME}"
+						}
+					},
+					"spec": {
+						"containers": [
+							{
+								"capabilities": {},
+								"env": [
+									{
+										"name": "MYSQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_ROOT_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-root-password",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_DATABASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-name",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									}
+								],
+								"image": " ",
+								"imagePullPolicy": "IfNotPresent",
+								"livenessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"
+										]
+									},
+									"initialDelaySeconds": 30,
+									"timeoutSeconds": 1
+								},
+								"name": "mysql",
+								"ports": [
+									{
+										"containerPort": 3306,
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"
+										]
+									},
+									"initialDelaySeconds": 5,
+									"timeoutSeconds": 1
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								},
+								"securityContext": {
+									"capabilities": {},
+									"privileged": false
+								},
+								"terminationMessagePath": "/dev/termination-log",
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/mysql/data",
+										"name": "${DATABASE_SERVICE_NAME}-data"
+									}
+								]
+							}
+						],
+						"dnsPolicy": "ClusterFirst",
+						"restartPolicy": "Always",
+						"volumes": [
+							{
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${DATABASE_SERVICE_NAME}-data"
+							}
+						]
+					}
+				}
+			},
+			"status": {}
+		}
+	],
+	"parameters": [
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Memory Limit",
+			"description": "Maximum amount of memory the container can use.",
+			"value": "512Mi",
+			"required": true
+		},
+		{
+			"name": "NAMESPACE",
+			"displayName": "Namespace",
+			"description": "The OpenShift Namespace where the ImageStream resides.",
+			"value": "openshift"
+		},
+		{
+			"name": "DATABASE_SERVICE_NAME",
+			"displayName": "Database Service Name",
+			"description": "The name of the OpenShift Service exposed for the database.",
+			"value": "mysql",
+			"required": true
+		},
+		{
+			"name": "MYSQL_USER",
+			"displayName": "MySQL Connection Username",
+			"description": "Username for MySQL user that will be used for accessing the database.",
+			"generate": "expression",
+			"from": "user[A-Z0-9]{3}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_PASSWORD",
+			"displayName": "MySQL Connection Password",
+			"description": "Password for the MySQL connection user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_ROOT_PASSWORD",
+			"displayName": "MySQL root user Password",
+			"description": "Password for the MySQL root user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_DATABASE",
+			"displayName": "MySQL Database Name",
+			"description": "Name of the MySQL database accessed.",
+			"value": "sampledb",
+			"required": true
+		},
+		{
+			"name": "MYSQL_VERSION",
+			"displayName": "Version of MySQL Image",
+			"description": "Version of MySQL image to be used (8.0-el7, 8.0-el8, or latest).",
+			"value": "8.0-el8",
+			"required": true
+		}
+	],
+	"labels": {
+		"app.openshift.io/runtime": "mysql-database",
+		"template": "mysql-ephemeral-template"
+	}
+}

--- a/assets/operator/okd-x86_64/mysql/templates/mysql-persistent.json
+++ b/assets/operator/okd-x86_64/mysql/templates/mysql-persistent.json
@@ -1,0 +1,274 @@
+{
+	"kind": "Template",
+	"apiVersion": "template.openshift.io/v1",
+	"metadata": {
+		"name": "mysql-persistent",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "MySQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.",
+			"iconClass": "icon-mysql-database",
+			"openshift.io/display-name": "MySQL",
+			"openshift.io/documentation-url": "https://docs.okd.io/latest/using_images/db_images/mysql.html",
+			"openshift.io/long-description": "This template provides a standalone MySQL server with a database created.  The database is stored on persistent storage.  The database name, username, and password are chosen via parameters when provisioning this service.",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"openshift.io/support-url": "https://access.redhat.com",
+			"tags": "database,mysql"
+		}
+	},
+	"message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${MYSQL_USER}\n       Password: ${MYSQL_PASSWORD}\n  Database Name: ${MYSQL_DATABASE}\n Connection URL: mysql://${DATABASE_SERVICE_NAME}:3306/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/8.0/root/usr/share/container-scripts/mysql/README.md.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Secret",
+			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-database_name": "{.data['database-name']}",
+					"template.openshift.io/expose-password": "{.data['database-password']}",
+					"template.openshift.io/expose-root_password": "{.data['database-root-password']}",
+					"template.openshift.io/expose-username": "{.data['database-user']}"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"stringData": {
+				"database-name": "${MYSQL_DATABASE}",
+				"database-password": "${MYSQL_PASSWORD}",
+				"database-root-password": "${MYSQL_ROOT_PASSWORD}",
+				"database-user": "${MYSQL_USER}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"template.openshift.io/expose-uri": "mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\"mysql\")].port}"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"name": "mysql",
+						"port": 3306
+					}
+				],
+				"selector": {
+					"name": "${DATABASE_SERVICE_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "PersistentVolumeClaim",
+			"metadata": {
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"accessModes": [
+					"ReadWriteOnce"
+				],
+				"resources": {
+					"requests": {
+						"storage": "${VOLUME_CAPACITY}"
+					}
+				}
+			}
+		},
+		{
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
+			"metadata": {
+				"annotations": {
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"template.alpha.openshift.io/wait-for-ready": "true"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"name": "${DATABASE_SERVICE_NAME}"
+						}
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "MYSQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_ROOT_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-root-password",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									},
+									{
+										"name": "MYSQL_DATABASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-name",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									}
+								],
+								"image": " ",
+								"imagePullPolicy": "IfNotPresent",
+								"livenessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"
+										]
+									},
+									"initialDelaySeconds": 30,
+									"timeoutSeconds": 1
+								},
+								"name": "mysql",
+								"ports": [
+									{
+										"containerPort": 3306
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"
+										]
+									},
+									"initialDelaySeconds": 5,
+									"timeoutSeconds": 1
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/mysql/data",
+										"name": "${DATABASE_SERVICE_NAME}-data"
+									}
+								]
+							}
+						],
+						"volumes": [
+							{
+								"name": "${DATABASE_SERVICE_NAME}-data",
+								"persistentVolumeClaim": {
+									"claimName": "${DATABASE_SERVICE_NAME}"
+								}
+							}
+						]
+					}
+				}
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Memory Limit",
+			"description": "Maximum amount of memory the container can use.",
+			"value": "512Mi",
+			"required": true
+		},
+		{
+			"name": "NAMESPACE",
+			"displayName": "Namespace",
+			"description": "The OpenShift Namespace where the ImageStream resides.",
+			"value": "openshift"
+		},
+		{
+			"name": "DATABASE_SERVICE_NAME",
+			"displayName": "Database Service Name",
+			"description": "The name of the OpenShift Service exposed for the database.",
+			"value": "mysql",
+			"required": true
+		},
+		{
+			"name": "MYSQL_USER",
+			"displayName": "MySQL Connection Username",
+			"description": "Username for MySQL user that will be used for accessing the database.",
+			"generate": "expression",
+			"from": "user[A-Z0-9]{3}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_PASSWORD",
+			"displayName": "MySQL Connection Password",
+			"description": "Password for the MySQL connection user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_ROOT_PASSWORD",
+			"displayName": "MySQL root user Password",
+			"description": "Password for the MySQL root user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}",
+			"required": true
+		},
+		{
+			"name": "MYSQL_DATABASE",
+			"displayName": "MySQL Database Name",
+			"description": "Name of the MySQL database accessed.",
+			"value": "sampledb",
+			"required": true
+		},
+		{
+			"name": "VOLUME_CAPACITY",
+			"displayName": "Volume Capacity",
+			"description": "Volume space available for data, e.g. 512Mi, 2Gi.",
+			"value": "1Gi",
+			"required": true
+		},
+		{
+			"name": "MYSQL_VERSION",
+			"displayName": "Version of MySQL Image",
+			"description": "Version of MySQL image to be used (8.0-el7, 8.0-el8, or latest).",
+			"value": "8.0-el8",
+			"required": true
+		}
+	],
+	"labels": {
+		"app.openshift.io/runtime": "mysql-database",
+		"template": "mysql-persistent-template"
+	}
+}

--- a/assets/operator/okd-x86_64/openliberty/imagestreams/openliberty.json
+++ b/assets/operator/okd-x86_64/openliberty/imagestreams/openliberty.json
@@ -14,11 +14,11 @@
 		},
 		"tags": [
 			{
-				"name": "24.0.0.3-java8",
+				"name": "24.0.0.9-java8",
 				"annotations": {
 					"description": "Build and run Open Liberty applications on Red Hat Universal Base Image 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/OpenLiberty/open-liberty-s2i/blob/main/README.md.",
 					"iconClass": "icon-openliberty",
-					"openshift.io/display-name": "Open Liberty 24.0.0.3 with Java 8",
+					"openshift.io/display-name": "Open Liberty 24.0.0.9 with Java 8",
 					"openshift.io/provider-display-name": "IBM",
 					"sampleRepo": "https://github.com/openshift/openshift-jee-sample.git",
 					"supports": "jee,java",
@@ -26,7 +26,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/openliberty/open-liberty-s2i:24.0.0.3-java8"
+					"name": "docker.io/openliberty/open-liberty-s2i:24.0.0.9-java8"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -35,11 +35,11 @@
 				}
 			},
 			{
-				"name": "24.0.0.3-java11",
+				"name": "24.0.0.9-java11",
 				"annotations": {
 					"description": "Build and run Open Liberty applications on Red Hat Universal Base Image 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/OpenLiberty/open-liberty-s2i/blob/main/README.md.",
 					"iconClass": "icon-openliberty",
-					"openshift.io/display-name": "Open Liberty 24.0.0.3 with Java 11",
+					"openshift.io/display-name": "Open Liberty 24.0.0.9 with Java 11",
 					"openshift.io/provider-display-name": "IBM",
 					"sampleRepo": "https://github.com/openshift/openshift-jee-sample.git",
 					"supports": "jee,java",
@@ -47,7 +47,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/openliberty/open-liberty-s2i:24.0.0.3-java11"
+					"name": "docker.io/openliberty/open-liberty-s2i:24.0.0.9-java11"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -56,11 +56,11 @@
 				}
 			},
 			{
-				"name": "24.0.0.3-java17",
+				"name": "24.0.0.9-java17",
 				"annotations": {
 					"description": "Build and run Open Liberty applications on Red Hat Universal Base Image 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/OpenLiberty/open-liberty-s2i/blob/main/README.md.",
 					"iconClass": "icon-openliberty",
-					"openshift.io/display-name": "Open Liberty 24.0.0.3 with Java 17",
+					"openshift.io/display-name": "Open Liberty 24.0.0.9 with Java 17",
 					"openshift.io/provider-display-name": "IBM",
 					"sampleRepo": "https://github.com/openshift/openshift-jee-sample.git",
 					"supports": "jee,java",
@@ -68,7 +68,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/openliberty/open-liberty-s2i:24.0.0.3-java17"
+					"name": "docker.io/openliberty/open-liberty-s2i:24.0.0.9-java17"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -77,11 +77,11 @@
 				}
 			},
 			{
-				"name": "24.0.0.3-java21",
+				"name": "24.0.0.9-java21",
 				"annotations": {
 					"description": "Build and run Open Liberty applications on Red Hat Universal Base Image 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/OpenLiberty/open-liberty-s2i/blob/main/README.md.",
 					"iconClass": "icon-openliberty",
-					"openshift.io/display-name": "Open Liberty 24.0.0.3 with Java 21",
+					"openshift.io/display-name": "Open Liberty 24.0.0.9 with Java 21",
 					"openshift.io/provider-display-name": "IBM",
 					"sampleRepo": "https://github.com/openshift/openshift-jee-sample.git",
 					"supports": "jee,java",
@@ -89,7 +89,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/openliberty/open-liberty-s2i:24.0.0.3-java21"
+					"name": "docker.io/openliberty/open-liberty-s2i:24.0.0.9-java21"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/okd-x86_64/postgresql/imagestreams/postgresql-centos.json
+++ b/assets/operator/okd-x86_64/postgresql/imagestreams/postgresql-centos.json
@@ -14,17 +14,18 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "13-el9",
 				"annotations": {
-					"description": "Provides a PostgreSQL database on CentOS Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of PostgreSQL available on OpenShift, including major version updates.",
+					"description": "Provides a PostgreSQL 13 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
 					"iconClass": "icon-postgresql",
-					"openshift.io/display-name": "PostgreSQL (Latest)",
+					"openshift.io/display-name": "PostgreSQL 13 (CentOS Stream 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"tags": "database,postgresql"
+					"tags": "database,postgresql",
+					"version": "13"
 				},
 				"from": {
-					"kind": "ImageStreamTag",
-					"name": "15-el9"
+					"kind": "DockerImage",
+					"name": "quay.io/sclorg/postgresql-13-c9s:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -53,18 +54,18 @@
 				}
 			},
 			{
-				"name": "13-el9",
+				"name": "16-el9",
 				"annotations": {
-					"description": "Provides a PostgreSQL 13 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+					"description": "Provides a PostgreSQL 16 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
 					"iconClass": "icon-postgresql",
-					"openshift.io/display-name": "PostgreSQL 13 (CentOS Stream 9)",
+					"openshift.io/display-name": "PostgreSQL 16 (CentOS Stream 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"tags": "database,postgresql",
-					"version": "13"
+					"version": "16"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay.io/sclorg/postgresql-13-c9s:latest"
+					"name": "quay.io/sclorg/postgresql-16-c9s:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -73,18 +74,18 @@
 				}
 			},
 			{
-				"name": "15-el8",
+				"name": "16-el10",
 				"annotations": {
-					"description": "Provides a PostgreSQL 15 database on CentOS Stream 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+					"description": "Provides a PostgreSQL 16 database on CentOS Stream 10. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
 					"iconClass": "icon-postgresql",
-					"openshift.io/display-name": "PostgreSQL 15 (CentOS Stream 8)",
+					"openshift.io/display-name": "PostgreSQL 16 (CentOS Stream 10)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"tags": "database,postgresql",
-					"version": "15"
+					"version": "16"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "quay.io/sclorg/postgresql-15-c8s:latest"
+					"name": "quay.io/sclorg/postgresql-16-c10s:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -93,58 +94,18 @@
 				}
 			},
 			{
-				"name": "13-el8",
+				"name": "latest",
 				"annotations": {
-					"description": "Provides a PostgreSQL 13 database on CentOS Stream 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+					"description": "Provides a PostgreSQL 16 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
 					"iconClass": "icon-postgresql",
-					"openshift.io/display-name": "PostgreSQL 13 (CentOS Stream 8)",
+					"openshift.io/display-name": "PostgreSQL 16 (Latest)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"tags": "database,postgresql",
-					"version": "13"
+					"version": "16"
 				},
 				"from": {
-					"kind": "DockerImage",
-					"name": "quay.io/sclorg/postgresql-13-c8s:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "12-el8",
-				"annotations": {
-					"description": "Provides a PostgreSQL 12 database on CentOS Stream 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
-					"iconClass": "icon-postgresql",
-					"openshift.io/display-name": "PostgreSQL 12 (CentOS Stream 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"tags": "database,postgresql",
-					"version": "12"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "quay.io/sclorg/postgresql-12-c8s:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "10-el8",
-				"annotations": {
-					"description": "Provides a PostgreSQL 10 database on CentOS Stream 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
-					"iconClass": "icon-postgresql",
-					"openshift.io/display-name": "PostgreSQL 10 (CentOS Stream 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"tags": "database,postgresql",
-					"version": "10"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "quay.io/sclorg/postgresql-10-c8s:latest"
+					"kind": "ImageStreamTag",
+					"name": "16-el9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/okd-x86_64/postgresql/templates/postgresql-ephemeral.json
+++ b/assets/operator/okd-x86_64/postgresql/templates/postgresql-ephemeral.json
@@ -64,10 +64,11 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -75,7 +76,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -176,27 +179,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_VERSION}",
-								"namespace": "${NAMESPACE}"
-							},
-							"lastTriggeredImage": ""
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			},
 			"status": {}
 		}
@@ -248,8 +231,8 @@
 		{
 			"name": "POSTGRESQL_VERSION",
 			"displayName": "Version of PostgreSQL Image",
-			"description": "Version of PostgreSQL image to be used (10-el7, 10-el8, or latest).",
-			"value": "10-el8",
+			"description": "Version of PostgreSQL image to be used (13-el8, 15-el8, or latest).",
+			"value": "15-el8",
 			"required": true
 		}
 	],

--- a/assets/operator/okd-x86_64/redis/imagestreams/redis-centos.json
+++ b/assets/operator/okd-x86_64/redis/imagestreams/redis-centos.json
@@ -1,0 +1,81 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "image.openshift.io/v1",
+	"metadata": {
+		"name": "redis",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "Redis"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "6-el9",
+				"annotations": {
+					"description": "Provides a Redis 6 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see  https://github.com/sclorg/redis-container/tree/master/6/README.md.",
+					"iconClass": "icon-redis",
+					"openshift.io/display-name": "Redis 6 (CentOS Stream 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "database,redis",
+					"version": "6"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "quay.io/sclorg/redis-6-c9s:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "7-el9",
+				"annotations": {
+					"description": "Provides a Redis 7 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see  https://github.com/sclorg/redis-container/tree/master/7/README.md.",
+					"iconClass": "icon-redis",
+					"openshift.io/display-name": "Redis 7 (CentOS Stream 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "database,redis",
+					"version": "7"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "quay.io/sclorg/redis-7-c9s:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Provides a Redis 6 database on CentOS Stream 9. For more information about using this database image, including OpenShift considerations, see  https://github.com/sclorg/redis-container/tree/master/6/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-redis",
+					"openshift.io/display-name": "Redis 6 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "database,redis",
+					"version": "6"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "6-el9"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/assets/operator/okd-x86_64/redis/templates/redis-ephemeral.json
+++ b/assets/operator/okd-x86_64/redis/templates/redis-ephemeral.json
@@ -1,0 +1,205 @@
+{
+	"kind": "Template",
+	"apiVersion": "template.openshift.io/v1",
+	"metadata": {
+		"name": "redis-ephemeral",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "Redis in-memory data structure store, without persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/redis-container/blob/master/5.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
+			"iconClass": "icon-redis",
+			"openshift.io/display-name": "Redis (Ephemeral)",
+			"openshift.io/documentation-url": "https://github.com/sclorg/redis-container/tree/master/5",
+			"openshift.io/long-description": "This template provides a standalone Redis server.  The data is not stored on persistent storage, so any restart of the service will result in all data being lost.",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"openshift.io/support-url": "https://access.redhat.com",
+			"tags": "database,redis"
+		}
+	},
+	"message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Password: ${REDIS_PASSWORD}\n Connection URL: redis://${DATABASE_SERVICE_NAME}:6379/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/redis-container/blob/master/5.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Secret",
+			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-password": "{.data['database-password']}"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"stringData": {
+				"database-password": "${REDIS_PASSWORD}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-uri": "redis://{.spec.clusterIP}:{.spec.ports[?(.name==\"redis\")].port}"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"name": "redis",
+						"nodePort": 0,
+						"port": 6379,
+						"protocol": "TCP",
+						"targetPort": 6379
+					}
+				],
+				"selector": {
+					"name": "${DATABASE_SERVICE_NAME}"
+				},
+				"sessionAffinity": "None",
+				"type": "ClusterIP"
+			},
+			"status": {
+				"loadBalancer": {}
+			}
+		},
+		{
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
+			"metadata": {
+				"annotations": {
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"redis:${REDIS_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"template.alpha.openshift.io/wait-for-ready": "true"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"name": "${DATABASE_SERVICE_NAME}"
+						}
+					},
+					"spec": {
+						"containers": [
+							{
+								"capabilities": {},
+								"env": [
+									{
+										"name": "REDIS_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${DATABASE_SERVICE_NAME}"
+											}
+										}
+									}
+								],
+								"image": " ",
+								"imagePullPolicy": "IfNotPresent",
+								"livenessProbe": {
+									"initialDelaySeconds": 30,
+									"tcpSocket": {
+										"port": 6379
+									},
+									"timeoutSeconds": 1
+								},
+								"name": "redis",
+								"ports": [
+									{
+										"containerPort": 6379,
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"test \"$(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping)\" == \"PONG\""
+										]
+									},
+									"initialDelaySeconds": 5,
+									"timeoutSeconds": 1
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								},
+								"securityContext": {
+									"capabilities": {},
+									"privileged": false
+								},
+								"terminationMessagePath": "/dev/termination-log",
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/redis/data",
+										"name": "${DATABASE_SERVICE_NAME}-data"
+									}
+								]
+							}
+						],
+						"dnsPolicy": "ClusterFirst",
+						"restartPolicy": "Always",
+						"volumes": [
+							{
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${DATABASE_SERVICE_NAME}-data"
+							}
+						]
+					}
+				}
+			},
+			"status": {}
+		}
+	],
+	"parameters": [
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Memory Limit",
+			"description": "Maximum amount of memory the container can use.",
+			"value": "512Mi",
+			"required": true
+		},
+		{
+			"name": "NAMESPACE",
+			"displayName": "Namespace",
+			"description": "The OpenShift Namespace where the ImageStream resides.",
+			"value": "openshift"
+		},
+		{
+			"name": "DATABASE_SERVICE_NAME",
+			"displayName": "Database Service Name",
+			"description": "The name of the OpenShift Service exposed for the database.",
+			"value": "redis",
+			"required": true
+		},
+		{
+			"name": "REDIS_PASSWORD",
+			"displayName": "Redis Connection Password",
+			"description": "Password for the Redis connection user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}",
+			"required": true
+		},
+		{
+			"name": "REDIS_VERSION",
+			"displayName": "Version of Redis Image",
+			"description": "Version of Redis image to be used (5-el7, 5-el8, 6-el7, 6-el8, or latest).",
+			"value": "6-el8",
+			"required": true
+		}
+	],
+	"labels": {
+		"template": "redis-ephemeral-template"
+	}
+}

--- a/assets/operator/okd-x86_64/redis/templates/redis-persistent.json
+++ b/assets/operator/okd-x86_64/redis/templates/redis-persistent.json
@@ -2,36 +2,32 @@
 	"kind": "Template",
 	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
-		"name": "postgresql-persistent",
+		"name": "redis-persistent",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "PostgreSQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.",
-			"iconClass": "icon-postgresql",
-			"openshift.io/display-name": "PostgreSQL",
-			"openshift.io/documentation-url": "https://docs.okd.io/latest/using_images/db_images/postgresql.html",
-			"openshift.io/long-description": "This template provides a standalone PostgreSQL server with a database created.  The database is stored on persistent storage.  The database name, username, and password are chosen via parameters when provisioning this service.",
+			"description": "Redis in-memory data structure store, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/redis-container/blob/master/5.\n\nNOTE: You must have persistent volumes available in your cluster to use this template.",
+			"iconClass": "icon-redis",
+			"openshift.io/display-name": "Redis",
+			"openshift.io/documentation-url": "https://github.com/sclorg/redis-container/tree/master/5",
+			"openshift.io/long-description": "This template provides a standalone Redis server.  The data is stored on persistent storage.",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"openshift.io/support-url": "https://access.redhat.com",
-			"tags": "database,postgresql"
+			"tags": "database,redis"
 		}
 	},
-	"message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${POSTGRESQL_USER}\n       Password: ${POSTGRESQL_PASSWORD}\n  Database Name: ${POSTGRESQL_DATABASE}\n Connection URL: postgresql://${DATABASE_SERVICE_NAME}:5432/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.",
+	"message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Password: ${REDIS_PASSWORD}\n Connection URL: redis://${DATABASE_SERVICE_NAME}:6379/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/redis-container/blob/master/5.",
 	"objects": [
 		{
 			"apiVersion": "v1",
 			"kind": "Secret",
 			"metadata": {
 				"annotations": {
-					"template.openshift.io/expose-database_name": "{.data['database-name']}",
-					"template.openshift.io/expose-password": "{.data['database-password']}",
-					"template.openshift.io/expose-username": "{.data['database-user']}"
+					"template.openshift.io/expose-password": "{.data['database-password']}"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
 			},
 			"stringData": {
-				"database-name": "${POSTGRESQL_DATABASE}",
-				"database-password": "${POSTGRESQL_PASSWORD}",
-				"database-user": "${POSTGRESQL_USER}"
+				"database-password": "${REDIS_PASSWORD}"
 			}
 		},
 		{
@@ -39,18 +35,18 @@
 			"kind": "Service",
 			"metadata": {
 				"annotations": {
-					"template.openshift.io/expose-uri": "postgres://{.spec.clusterIP}:{.spec.ports[?(.name==\"postgresql\")].port}"
+					"template.openshift.io/expose-uri": "redis://{.spec.clusterIP}:{.spec.ports[?(.name==\"redis\")].port}"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
 			},
 			"spec": {
 				"ports": [
 					{
-						"name": "postgresql",
+						"name": "redis",
 						"nodePort": 0,
-						"port": 5432,
+						"port": 6379,
 						"protocol": "TCP",
-						"targetPort": 5432
+						"targetPort": 6379
 					}
 				],
 				"selector": {
@@ -85,7 +81,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"redis:${REDIS_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -112,28 +108,10 @@
 								"capabilities": {},
 								"env": [
 									{
-										"name": "POSTGRESQL_USER",
-										"valueFrom": {
-											"secretKeyRef": {
-												"key": "database-user",
-												"name": "${DATABASE_SERVICE_NAME}"
-											}
-										}
-									},
-									{
-										"name": "POSTGRESQL_PASSWORD",
+										"name": "REDIS_PASSWORD",
 										"valueFrom": {
 											"secretKeyRef": {
 												"key": "database-password",
-												"name": "${DATABASE_SERVICE_NAME}"
-											}
-										}
-									},
-									{
-										"name": "POSTGRESQL_DATABASE",
-										"valueFrom": {
-											"secretKeyRef": {
-												"key": "database-name",
 												"name": "${DATABASE_SERVICE_NAME}"
 											}
 										}
@@ -142,26 +120,26 @@
 								"image": " ",
 								"imagePullPolicy": "IfNotPresent",
 								"livenessProbe": {
-									"exec": {
-										"command": [
-											"/usr/libexec/check-container",
-											"--live"
-										]
+									"initialDelaySeconds": 30,
+									"tcpSocket": {
+										"port": 6379
 									},
-									"initialDelaySeconds": 120,
-									"timeoutSeconds": 10
+									"timeoutSeconds": 1
 								},
-								"name": "postgresql",
+								"name": "redis",
 								"ports": [
 									{
-										"containerPort": 5432,
+										"containerPort": 6379,
 										"protocol": "TCP"
 									}
 								],
 								"readinessProbe": {
 									"exec": {
 										"command": [
-											"/usr/libexec/check-container"
+											"/bin/sh",
+											"-i",
+											"-c",
+											"test \"$(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping)\" == \"PONG\""
 										]
 									},
 									"initialDelaySeconds": 5,
@@ -179,7 +157,7 @@
 								"terminationMessagePath": "/dev/termination-log",
 								"volumeMounts": [
 									{
-										"mountPath": "/var/lib/pgsql/data",
+										"mountPath": "/var/lib/redis/data",
 										"name": "${DATABASE_SERVICE_NAME}-data"
 									}
 								]
@@ -219,30 +197,15 @@
 			"name": "DATABASE_SERVICE_NAME",
 			"displayName": "Database Service Name",
 			"description": "The name of the OpenShift Service exposed for the database.",
-			"value": "postgresql",
+			"value": "redis",
 			"required": true
 		},
 		{
-			"name": "POSTGRESQL_USER",
-			"displayName": "PostgreSQL Connection Username",
-			"description": "Username for PostgreSQL user that will be used for accessing the database.",
-			"generate": "expression",
-			"from": "user[A-Z0-9]{3}",
-			"required": true
-		},
-		{
-			"name": "POSTGRESQL_PASSWORD",
-			"displayName": "PostgreSQL Connection Password",
-			"description": "Password for the PostgreSQL connection user.",
+			"name": "REDIS_PASSWORD",
+			"displayName": "Redis Connection Password",
+			"description": "Password for the Redis connection user.",
 			"generate": "expression",
 			"from": "[a-zA-Z0-9]{16}",
-			"required": true
-		},
-		{
-			"name": "POSTGRESQL_DATABASE",
-			"displayName": "PostgreSQL Database Name",
-			"description": "Name of the PostgreSQL database accessed.",
-			"value": "sampledb",
 			"required": true
 		},
 		{
@@ -253,14 +216,14 @@
 			"required": true
 		},
 		{
-			"name": "POSTGRESQL_VERSION",
-			"displayName": "Version of PostgreSQL Image",
-			"description": "Version of PostgreSQL image to be used (13-el8, 15-el8, or latest).",
-			"value": "15-el8",
+			"name": "REDIS_VERSION",
+			"displayName": "Version of Redis Image",
+			"description": "Version of Redis image to be used (5-el7, 5-el8, 6-el7, 6-el8, or latest).",
+			"value": "6-el8",
 			"required": true
 		}
 	],
 	"labels": {
-		"template": "postgresql-persistent-template"
+		"template": "redis-persistent-template"
 	}
 }


### PR DESCRIPTION
It turns out that there is a test for particular samples being imported into the imagestreams
https://github.com/openshift/origin/blob/master/test/extended/util/framework.go#L315 is the list. so lets add back mysql even though it is unsupported