### PR TITLE
OCPBUGS-39120: Sync the non-OKD assets from master to release-4.17

### DIFF
--- a/assets/operator/ocp-aarch64/dotnet/imagestreams/dotnet-rhel-aarch64.json
+++ b/assets/operator/ocp-aarch64/dotnet/imagestreams/dotnet-rhel-aarch64.json
@@ -83,52 +83,6 @@
 				}
 			},
 			{
-				"name": "7.0-ubi8",
-				"annotations": {
-					"description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 (UBI 8)",
-					"sampleContextDir": "app",
-					"sampleRef": "dotnet-7.0",
-					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-					"supports": "dotnet:7.0,dotnet",
-					"tags": "builder,.net,dotnet,dotnetcore,dotnet70",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "7.0",
-				"annotations": {
-					"description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 (UBI 8)",
-					"sampleContextDir": "app",
-					"sampleRef": "dotnetcore-7.0",
-					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-					"supports": "dotnet:7.0,dotnet",
-					"tags": "builder,.net,dotnet,dotnetcore,dotnet70,hidden",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "6.0-ubi8",
 				"annotations": {
 					"description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",

--- a/assets/operator/ocp-aarch64/dotnet/imagestreams/dotnet-runtime-rhel-aarch64.json
+++ b/assets/operator/ocp-aarch64/dotnet/imagestreams/dotnet-runtime-rhel-aarch64.json
@@ -74,46 +74,6 @@
 				}
 			},
 			{
-				"name": "7.0-ubi8",
-				"annotations": {
-					"description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-					"supports": "dotnet-runtime",
-					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "7.0",
-				"annotations": {
-					"description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-					"supports": "dotnet-runtime",
-					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "6.0-ubi8",
 				"annotations": {
 					"description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",

--- a/assets/operator/ocp-aarch64/nginx/imagestreams/nginx-rhel-aarch64.json
+++ b/assets/operator/ocp-aarch64/nginx/imagestreams/nginx-rhel-aarch64.json
@@ -77,19 +77,40 @@
 				}
 			},
 			{
-				"name": "latest",
+				"name": "1.24-ubi9",
 				"annotations": {
-					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.",
 					"iconClass": "icon-nginx",
-					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (Latest)",
+					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
 					"tags": "builder,nginx",
-					"version": "1.22"
+					"version": "1.24"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nginx-124:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-nginx",
+					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+					"tags": "builder,nginx",
+					"version": "1.24"
 				},
 				"from": {
 					"kind": "ImageStreamTag",
-					"name": "1.22-ubi8"
+					"name": "1.24-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-aarch64/nodejs/imagestreams/nodejs-rhel-aarch64.json
+++ b/assets/operator/ocp-aarch64/nodejs/imagestreams/nodejs-rhel-aarch64.json
@@ -14,74 +14,11 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "18-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+					"description": "Build and run Node.js 18 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js (Latest)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"supports": "nodejs",
-					"tags": "builder,nodejs"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "20-ubi9"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "20-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "20"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-20:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "20-ubi9-minimal",
-				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 9 Minimal)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "20"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "18-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 9)",
+					"openshift.io/display-name": "Node.js 18 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
@@ -89,7 +26,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-18:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-18:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -98,19 +35,19 @@
 				}
 			},
 			{
-				"name": "18-ubi9-minimal",
+				"name": "18-minimal-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 9 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "18"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -140,15 +77,15 @@
 				}
 			},
 			{
-				"name": "20-ubi8-minimal",
+				"name": "20-minimal-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "20"
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
@@ -161,11 +98,11 @@
 				}
 			},
 			{
-				"name": "18-ubi8",
+				"name": "18-ubi9",
 				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
+					"description": "Build and run Node.js 18 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 8)",
+					"openshift.io/display-name": "Node.js 18 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
@@ -173,7 +110,70 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-18:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-18:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "18-minimal-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 18-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "18-minimal"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "20-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-20:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "20-minimal-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 20-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20-minimal"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -184,13 +184,13 @@
 			{
 				"name": "18-ubi8-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "18"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
@@ -203,19 +203,19 @@
 				}
 			},
 			{
-				"name": "16-ubi9",
+				"name": "20-ubi8-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 9)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-16:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-20-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -224,19 +224,19 @@
 				}
 			},
 			{
-				"name": "16-ubi9-minimal",
+				"name": "18-ubi9-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 9 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-16-minimal:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -245,19 +245,19 @@
 				}
 			},
 			{
-				"name": "16-ubi8",
+				"name": "20-ubi9-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 8)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-16:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -266,19 +266,19 @@
 				}
 			},
 			{
-				"name": "16-ubi8-minimal",
+				"name": "latest",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 20 (Latest)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "20"
 				},
 				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-16-minimal:latest"
+					"kind": "ImageStreamTag",
+					"name": "20-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-aarch64/nodejs/templates/nodejs-postgresql-example.json
+++ b/assets/operator/ocp-aarch64/nodejs/templates/nodejs-postgresql-example.json
@@ -422,8 +422,8 @@
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-			"value": "16-ubi8",
+			"description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+			"value": "18-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-aarch64/nodejs/templates/nodejs-postgresql-persistent.json
+++ b/assets/operator/ocp-aarch64/nodejs/templates/nodejs-postgresql-persistent.json
@@ -439,8 +439,8 @@
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-			"value": "16-ubi8",
+			"description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+			"value": "18-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-aarch64/perl/imagestreams/perl-rhel-aarch64.json
+++ b/assets/operator/ocp-aarch64/perl/imagestreams/perl-rhel-aarch64.json
@@ -14,41 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "5.26-ubi8",
 				"annotations": {
-					"description": "Build and run Perl applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Perl available on OpenShift, including major version updates.",
+					"description": "Build and run Perl 5.26 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl (Latest)",
+					"openshift.io/display-name": "Perl 5.26 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl",
-					"tags": "builder,perl"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "5.32-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "5.32-ubi9",
-				"annotations": {
-					"description": "Build and run Perl 5.32 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
-					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.32 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.32,perl",
 					"tags": "builder,perl",
-					"version": "5.32"
+					"version": "5.26"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/perl-532:latest"
+					"name": "registry.redhat.io/ubi8/perl-526:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -64,7 +42,6 @@
 					"openshift.io/display-name": "Perl 5.32 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.32,perl",
 					"tags": "builder,perl",
 					"version": "5.32"
 				},
@@ -79,20 +56,40 @@
 				}
 			},
 			{
-				"name": "5.26-ubi8",
+				"name": "5.32-ubi9",
 				"annotations": {
-					"description": "Build and run Perl 5.26 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26-mod_fcgid/README.md.",
+					"description": "Build and run Perl 5.32 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.26 (UBI 8)",
+					"openshift.io/display-name": "Perl 5.32 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.26,perl",
 					"tags": "builder,perl",
-					"version": "5.26"
+					"version": "5.32"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/perl-526:latest"
+					"name": "registry.redhat.io/ubi9/perl-532:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-perl",
+					"openshift.io/display-name": "Perl 5.32 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
+					"tags": "builder,perl",
+					"version": "5.32"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "5.32-ubi8"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-aarch64/php/imagestreams/php-rhel-aarch64.json
+++ b/assets/operator/ocp-aarch64/php/imagestreams/php-rhel-aarch64.json
@@ -56,6 +56,27 @@
 				}
 			},
 			{
+				"name": "8.2-ubi8",
+				"annotations": {
+					"description": "Build and run PHP 8.2 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+					"iconClass": "icon-php",
+					"openshift.io/display-name": "PHP 8.2 (UBI 8)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
+					"tags": "builder,php",
+					"version": "8.2"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8/php-82:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
 				"name": "8.0-ubi9",
 				"annotations": {
 					"description": "Build and run PHP 8.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.0/README.md.",
@@ -90,6 +111,27 @@
 				"from": {
 					"kind": "DockerImage",
 					"name": "registry.redhat.io/ubi9/php-81:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "8.2-ubi9",
+				"annotations": {
+					"description": "Build and run PHP 8.2 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+					"iconClass": "icon-php",
+					"openshift.io/display-name": "PHP 8.2 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
+					"tags": "builder,php",
+					"version": "8.2"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/php-82:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-aarch64/python/imagestreams/python-rhel-aarch64.json
+++ b/assets/operator/ocp-aarch64/python/imagestreams/python-rhel-aarch64.json
@@ -14,63 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "3.6-ubi8",
 				"annotations": {
-					"description": "Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.",
+					"description": "Build and run Python 3.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python (Latest)",
+					"openshift.io/display-name": "Python 3.6 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python",
-					"tags": "builder,python"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "3.9-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.9-ubi9",
-				"annotations": {
-					"description": "Build and run Python 3.9 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.9 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.9,python",
 					"tags": "builder,python",
-					"version": "3.9"
+					"version": "3.6"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/python-39:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.9-ubi8",
-				"annotations": {
-					"description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.9 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.9,python",
-					"tags": "builder,python",
-					"version": "3.9"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-39:latest"
+					"name": "registry.redhat.io/ubi8/python-36:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -86,7 +42,6 @@
 					"openshift.io/display-name": "Python 3.8 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
 					"tags": "builder,python",
 					"version": "3.8"
 				},
@@ -101,20 +56,19 @@
 				}
 			},
 			{
-				"name": "3.6-ubi8",
+				"name": "3.9-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
+					"description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.6 (UBI 8)",
+					"openshift.io/display-name": "Python 3.9 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.6,python",
 					"tags": "builder,python",
-					"version": "3.6"
+					"version": "3.9"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-36:latest"
+					"name": "registry.redhat.io/ubi8/python-39:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -123,20 +77,82 @@
 				}
 			},
 			{
-				"name": "2.7-ubi8",
+				"name": "3.12-ubi8",
 				"annotations": {
-					"description": "Build and run Python 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
+					"description": "Build and run Python 3.12 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 2.7 (UBI 8)",
+					"openshift.io/display-name": "Python 3.12 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:2.7,python",
 					"tags": "builder,python",
-					"version": "2.7"
+					"version": "3.12"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-27:latest"
+					"name": "registry.redhat.io/ubi8/python-312:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.9-ubi9",
+				"annotations": {
+					"description": "Build and run Python 3.9 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.9 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.9"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/python-39:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.12-ubi9",
+				"annotations": {
+					"description": "Build and run Python 3.12 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.12 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.12"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/python-312:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.9 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.9"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "3.9-ubi8"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-aarch64/rails/templates/rails-pgsql-persistent.json
+++ b/assets/operator/ocp-aarch64/rails/templates/rails-pgsql-persistent.json
@@ -7,13 +7,12 @@
 		"annotations": {
 			"description": "An example Rails application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
 			"iconClass": "icon-ruby",
-			"openshift.io/display-name": "Rails + PostgreSQL",
-			"openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
-			"openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.",
-			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"openshift.io/support-url": "https://access.redhat.com",
+			"openshift.io/display-name": "Rails + PostgreSQL (Persistent)",
 			"tags": "quickstart,ruby,rails",
-			"template.openshift.io/bindable": "false"
+			"template.openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
+			"template.openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.",
+			"template.openshift.io/provider-display-name": "Red Hat, Inc.",
+			"template.openshift.io/support-url": "https://access.redhat.com"
 		}
 	},
 	"message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
@@ -22,6 +21,10 @@
 			"apiVersion": "v1",
 			"kind": "Secret",
 			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-password": "{.data['application-password']}",
+					"template.openshift.io/expose-username": "{.data['application-user']}"
+				},
 				"name": "${NAME}"
 			},
 			"stringData": {
@@ -59,6 +62,9 @@
 			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-uri": "http://{.spec.host}{.spec.path}"
+				},
 				"name": "${NAME}"
 			},
 			"spec": {
@@ -96,9 +102,6 @@
 						"name": "${NAME}:latest"
 					}
 				},
-				"postCommit": {
-					"script": "bundle exec rake test"
-				},
 				"source": {
 					"contextDir": "${CONTEXT_DIR}",
 					"git": {
@@ -117,7 +120,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:${RUBY_VERSION}",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -140,11 +143,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"},{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.initContainers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -152,20 +156,11 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
-					"recreateParams": {
-						"pre": {
-							"execNewPod": {
-								"command": [
-									"./migrate-database.sh"
-								],
-								"containerName": "${NAME}"
-							},
-							"failurePolicy": "Abort"
-						}
-					},
 					"type": "Recreate"
 				},
 				"template": {
@@ -278,27 +273,89 @@
 									}
 								}
 							}
+						],
+						"initContainers": [
+							{
+								"command": [
+									"./migrate-database.sh"
+								],
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "SECRET_KEY_BASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "keybase",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									},
+									{
+										"name": "APPLICATION_DOMAIN",
+										"value": "${APPLICATION_DOMAIN}"
+									},
+									{
+										"name": "APPLICATION_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "APPLICATION_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "RAILS_ENV",
+										"value": "${RAILS_ENV}"
+									}
+								],
+								"image": " ",
+								"name": "ruby-init-container"
+							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -341,11 +398,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\", \"namespace\": \"openshift\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -353,7 +411,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -448,26 +508,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],
@@ -484,6 +525,20 @@
 			"displayName": "Namespace",
 			"description": "The OpenShift Namespace where the ImageStream resides.",
 			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "RUBY_VERSION",
+			"displayName": "Ruby Version",
+			"description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+			"value": "3.1-ubi8",
+			"required": true
+		},
+		{
+			"name": "POSTGRESQL_VERSION",
+			"displayName": "Postgresql Version",
+			"description": "Version of Postgresql image to be used (12-el8 by default).",
+			"value": "12-el8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-aarch64/rails/templates/rails-postgresql-example.json
+++ b/assets/operator/ocp-aarch64/rails/templates/rails-postgresql-example.json
@@ -96,9 +96,6 @@
 						"name": "${NAME}:latest"
 					}
 				},
-				"postCommit": {
-					"script": "bundle exec rake test"
-				},
 				"source": {
 					"contextDir": "${CONTEXT_DIR}",
 					"git": {
@@ -117,7 +114,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:${RUBY_VERSION}",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -140,11 +137,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"},{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.initContainers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -152,7 +150,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
 					"recreateParams": {
@@ -278,27 +278,89 @@
 									}
 								}
 							}
+						],
+						"initContainers": [
+							{
+								"command": [
+									"./migrate-database.sh"
+								],
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "SECRET_KEY_BASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "keybase",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									},
+									{
+										"name": "APPLICATION_DOMAIN",
+										"value": "${APPLICATION_DOMAIN}"
+									},
+									{
+										"name": "APPLICATION_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "APPLICATION_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "RAILS_ENV",
+										"value": "${RAILS_ENV}"
+									}
+								],
+								"image": " ",
+								"name": "ruby-init-container"
+							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -324,11 +386,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:12-el8\", \"namespace\": \"openshift\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -336,7 +399,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -429,26 +494,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],
@@ -465,6 +511,13 @@
 			"displayName": "Namespace",
 			"description": "The OpenShift Namespace where the ImageStream resides.",
 			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "RUBY_VERSION",
+			"displayName": "Ruby Version",
+			"description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+			"value": "3.1-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-aarch64/ruby/imagestreams/ruby-rhel-aarch64.json
+++ b/assets/operator/ocp-aarch64/ruby/imagestreams/ruby-rhel-aarch64.json
@@ -14,63 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "2.5-ubi8",
 				"annotations": {
-					"description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.1/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+					"description": "Build and run Ruby 2.5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby (Latest)",
+					"openshift.io/display-name": "Ruby 2.5 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby",
-					"tags": "builder,ruby"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "3.1-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.1-ubi9",
-				"annotations": {
-					"description": "Build and run Ruby 3.1 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
-					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.1 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.1,ruby",
 					"tags": "builder,ruby",
-					"version": "3.1"
+					"version": "2.5"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/ruby-31:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.0-ubi9",
-				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
-					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
-					"tags": "builder,ruby",
-					"version": "3.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/ruby-30:latest"
+					"name": "registry.redhat.io/ubi8/ruby-25:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -86,7 +42,6 @@
 					"openshift.io/display-name": "Ruby 3.1 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.1,ruby",
 					"tags": "builder,ruby",
 					"version": "3.1"
 				},
@@ -101,20 +56,19 @@
 				}
 			},
 			{
-				"name": "3.0-ubi8",
+				"name": "3.3-ubi8",
 				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+					"description": "Build and run Ruby 3.3 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 8)",
+					"openshift.io/display-name": "Ruby 3.3 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
 					"tags": "builder,ruby",
-					"version": "3.0"
+					"version": "3.3"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/ruby-30:latest"
+					"name": "registry.redhat.io/ubi8/ruby-33:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -123,20 +77,82 @@
 				}
 			},
 			{
-				"name": "2.5-ubi8",
+				"name": "3.0-ubi9",
 				"annotations": {
-					"description": "Build and run Ruby 2.5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
+					"description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 2.5 (UBI 8)",
+					"openshift.io/display-name": "Ruby 3.0 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:2.5,ruby",
 					"tags": "builder,ruby",
-					"version": "2.5"
+					"version": "3.0"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/ruby-25:latest"
+					"name": "registry.redhat.io/ubi9/ruby-30:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.1-ubi9",
+				"annotations": {
+					"description": "Build and run Ruby 3.1 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 3.1 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"tags": "builder,ruby",
+					"version": "3.1"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/ruby-31:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.3-ubi9",
+				"annotations": {
+					"description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 3.3 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"tags": "builder,ruby",
+					"version": "3.3"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/ruby-33:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 3.3 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"tags": "builder,ruby",
+					"version": "3.3"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "3.3-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-ppc64le/dotnet/imagestreams/dotnet-rhel-ppc64le.json
+++ b/assets/operator/ocp-ppc64le/dotnet/imagestreams/dotnet-rhel-ppc64le.json
@@ -81,52 +81,6 @@
 				"referencePolicy": {
 					"type": "Local"
 				}
-			},
-			{
-				"name": "7.0-ubi8",
-				"annotations": {
-					"description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 (UBI 8)",
-					"sampleContextDir": "app",
-					"sampleRef": "dotnet-7.0",
-					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-					"supports": "dotnet:7.0,dotnet",
-					"tags": "builder,.net,dotnet,dotnetcore,dotnet70",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "7.0",
-				"annotations": {
-					"description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 (UBI 8)",
-					"sampleContextDir": "app",
-					"sampleRef": "dotnetcore-7.0",
-					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-					"supports": "dotnet:7.0,dotnet",
-					"tags": "builder,.net,dotnet,dotnetcore,dotnet70,hidden",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
 			}
 		]
 	},

--- a/assets/operator/ocp-ppc64le/dotnet/imagestreams/dotnet-runtime-rhel-ppc64le.json
+++ b/assets/operator/ocp-ppc64le/dotnet/imagestreams/dotnet-runtime-rhel-ppc64le.json
@@ -72,46 +72,6 @@
 				"referencePolicy": {
 					"type": "Local"
 				}
-			},
-			{
-				"name": "7.0-ubi8",
-				"annotations": {
-					"description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-					"supports": "dotnet-runtime",
-					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "7.0",
-				"annotations": {
-					"description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-					"supports": "dotnet-runtime",
-					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
 			}
 		]
 	},

--- a/assets/operator/ocp-ppc64le/httpd/imagestreams/httpd-rhel.json
+++ b/assets/operator/ocp-ppc64le/httpd/imagestreams/httpd-rhel.json
@@ -56,27 +56,6 @@
 				}
 			},
 			{
-				"name": "2.4-el7",
-				"annotations": {
-					"description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
-					"iconClass": "icon-httpd",
-					"openshift.io/display-name": "Apache HTTP Server 2.4 (RHEL 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/httpd-ex.git",
-					"tags": "builder,httpd",
-					"version": "2.4"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/httpd-24-rhel7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "2.4-el8",
 				"annotations": {
 					"description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",

--- a/assets/operator/ocp-ppc64le/nginx/imagestreams/nginx-rhel.json
+++ b/assets/operator/ocp-ppc64le/nginx/imagestreams/nginx-rhel.json
@@ -14,27 +14,6 @@
 		},
 		"tags": [
 			{
-				"name": "1.20-ubi7",
-				"annotations": {
-					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
-					"iconClass": "icon-nginx",
-					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-					"tags": "builder,nginx",
-					"version": "1.20"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/nginx-120:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "1.22-ubi8",
 				"annotations": {
 					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
@@ -98,19 +77,40 @@
 				}
 			},
 			{
-				"name": "latest",
+				"name": "1.24-ubi9",
 				"annotations": {
-					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.",
 					"iconClass": "icon-nginx",
-					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (Latest)",
+					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
 					"tags": "builder,nginx",
-					"version": "1.22"
+					"version": "1.24"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nginx-124:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-nginx",
+					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+					"tags": "builder,nginx",
+					"version": "1.24"
 				},
 				"from": {
 					"kind": "ImageStreamTag",
-					"name": "1.22-ubi8"
+					"name": "1.24-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-ppc64le/nodejs/imagestreams/nodejs-rhel.json
+++ b/assets/operator/ocp-ppc64le/nodejs/imagestreams/nodejs-rhel.json
@@ -14,53 +14,11 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "18-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+					"description": "Build and run Node.js 18 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js (Latest)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"supports": "nodejs",
-					"tags": "builder,nodejs"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "20-ubi9"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "20-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "20"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-20:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "18-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 9)",
+					"openshift.io/display-name": "Node.js 18 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
@@ -68,7 +26,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-18:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-18:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -77,82 +35,19 @@
 				}
 			},
 			{
-				"name": "20-ubi9-minimal",
+				"name": "18-minimal-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 9 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "20"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "18-ubi9-minimal",
-				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 9 Minimal)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "18"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "16-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "16"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-16:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "16-ubi9-minimal",
-				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 9 Minimal)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "16"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-16-minimal:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -182,15 +77,15 @@
 				}
 			},
 			{
-				"name": "20-ubi8-minimal",
+				"name": "20-minimal-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "20"
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
@@ -203,11 +98,11 @@
 				}
 			},
 			{
-				"name": "18-ubi8",
+				"name": "18-ubi9",
 				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
+					"description": "Build and run Node.js 18 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 8)",
+					"openshift.io/display-name": "Node.js 18 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
@@ -215,7 +110,70 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-18:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-18:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "18-minimal-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 18-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "18-minimal"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "20-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-20:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "20-minimal-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 20-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20-minimal"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -226,13 +184,13 @@
 			{
 				"name": "18-ubi8-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "18"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
@@ -245,19 +203,19 @@
 				}
 			},
 			{
-				"name": "16-ubi8",
+				"name": "20-ubi8-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 8)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-16:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-20-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -266,19 +224,19 @@
 				}
 			},
 			{
-				"name": "16-ubi8-minimal",
+				"name": "18-ubi9-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-16-minimal:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -287,19 +245,40 @@
 				}
 			},
 			{
-				"name": "14-ubi7",
+				"name": "20-ubi9-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 14 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 14 (UBI 7)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs,hidden",
-					"version": "14"
+					"tags": "builder,nodejs",
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/nodejs-14:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "20-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-ppc64le/nodejs/templates/nodejs-postgresql-example.json
+++ b/assets/operator/ocp-ppc64le/nodejs/templates/nodejs-postgresql-example.json
@@ -422,8 +422,8 @@
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-			"value": "16-ubi8",
+			"description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+			"value": "18-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-ppc64le/nodejs/templates/nodejs-postgresql-persistent.json
+++ b/assets/operator/ocp-ppc64le/nodejs/templates/nodejs-postgresql-persistent.json
@@ -439,8 +439,8 @@
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-			"value": "16-ubi8",
+			"description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+			"value": "18-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-ppc64le/perl/imagestreams/perl-rhel.json
+++ b/assets/operator/ocp-ppc64le/perl/imagestreams/perl-rhel.json
@@ -14,41 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "5.26-ubi8",
 				"annotations": {
-					"description": "Build and run Perl applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Perl available on OpenShift, including major version updates.",
+					"description": "Build and run Perl 5.26 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl (Latest)",
+					"openshift.io/display-name": "Perl 5.26 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl",
-					"tags": "builder,perl"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "5.32-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "5.32-ubi9",
-				"annotations": {
-					"description": "Build and run Perl 5.32 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
-					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.32 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.32,perl",
 					"tags": "builder,perl",
-					"version": "5.32"
+					"version": "5.26"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/perl-532:latest"
+					"name": "registry.redhat.io/ubi8/perl-526:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -64,7 +42,6 @@
 					"openshift.io/display-name": "Perl 5.32 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.32,perl",
 					"tags": "builder,perl",
 					"version": "5.32"
 				},
@@ -79,20 +56,19 @@
 				}
 			},
 			{
-				"name": "5.30-el7",
+				"name": "5.32-ubi9",
 				"annotations": {
-					"description": "Build and run Perl 5.30 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
+					"description": "Build and run Perl 5.32 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.30 (RHEL 7)",
+					"openshift.io/display-name": "Perl 5.32 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.30,perl",
 					"tags": "builder,perl",
-					"version": "5.30"
+					"version": "5.32"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/perl-530-rhel7:latest"
+					"name": "registry.redhat.io/ubi9/perl-532:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -101,42 +77,19 @@
 				}
 			},
 			{
-				"name": "5.30",
+				"name": "latest",
 				"annotations": {
-					"description": "Build and run Perl 5.30 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
+					"description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.30",
+					"openshift.io/display-name": "Perl 5.32 (Latest)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.30,perl",
-					"tags": "builder,perl,hidden",
-					"version": "5.30"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/perl-530-rhel7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "5.26-ubi8",
-				"annotations": {
-					"description": "Build and run Perl 5.26 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26-mod_fcgid/README.md.",
-					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.26 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.26,perl",
 					"tags": "builder,perl",
-					"version": "5.26"
+					"version": "5.32"
 				},
 				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/perl-526:latest"
+					"kind": "ImageStreamTag",
+					"name": "5.32-ubi8"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-ppc64le/php/imagestreams/php-rhel.json
+++ b/assets/operator/ocp-ppc64le/php/imagestreams/php-rhel.json
@@ -14,27 +14,6 @@
 		},
 		"tags": [
 			{
-				"name": "7.3-ubi7",
-				"annotations": {
-					"description": "Build and run PHP 7.3 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.",
-					"iconClass": "icon-php",
-					"openshift.io/display-name": "PHP 7.3 (UBI 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
-					"tags": "builder,php",
-					"version": "7.3"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/php-73:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "7.4-ubi8",
 				"annotations": {
 					"description": "Build and run PHP 7.4 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.4/README.md.",
@@ -77,6 +56,27 @@
 				}
 			},
 			{
+				"name": "8.2-ubi8",
+				"annotations": {
+					"description": "Build and run PHP 8.2 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+					"iconClass": "icon-php",
+					"openshift.io/display-name": "PHP 8.2 (UBI 8)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
+					"tags": "builder,php",
+					"version": "8.2"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8/php-82:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
 				"name": "8.0-ubi9",
 				"annotations": {
 					"description": "Build and run PHP 8.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.0/README.md.",
@@ -111,6 +111,27 @@
 				"from": {
 					"kind": "DockerImage",
 					"name": "registry.redhat.io/ubi9/php-81:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "8.2-ubi9",
+				"annotations": {
+					"description": "Build and run PHP 8.2 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+					"iconClass": "icon-php",
+					"openshift.io/display-name": "PHP 8.2 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
+					"tags": "builder,php",
+					"version": "8.2"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/php-82:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-ppc64le/python/imagestreams/python-rhel.json
+++ b/assets/operator/ocp-ppc64le/python/imagestreams/python-rhel.json
@@ -14,107 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "3.6-ubi8",
 				"annotations": {
-					"description": "Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.",
+					"description": "Build and run Python 3.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python (Latest)",
+					"openshift.io/display-name": "Python 3.6 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python",
-					"tags": "builder,python"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "3.11-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.11-ubi9",
-				"annotations": {
-					"description": "Build and run Python 3.11 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.11 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.11,python",
 					"tags": "builder,python",
-					"version": "3.11"
+					"version": "3.6"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/python-311:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.11-ubi8",
-				"annotations": {
-					"description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.11 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.11,python",
-					"tags": "builder,python",
-					"version": "3.11"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-311:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.9-ubi9",
-				"annotations": {
-					"description": "Build and run Python 3.9 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.9 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.9,python",
-					"tags": "builder,python",
-					"version": "3.9"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/python-39:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.9-ubi8",
-				"annotations": {
-					"description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.9 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.9,python",
-					"tags": "builder,python",
-					"version": "3.9"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-39:latest"
+					"name": "registry.redhat.io/ubi8/python-36:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -130,7 +42,6 @@
 					"openshift.io/display-name": "Python 3.8 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
 					"tags": "builder,python",
 					"version": "3.8"
 				},
@@ -145,20 +56,19 @@
 				}
 			},
 			{
-				"name": "3.8-ubi7",
+				"name": "3.9-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.8 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+					"description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.8 (UBI 7)",
+					"openshift.io/display-name": "Python 3.9 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
 					"tags": "builder,python",
-					"version": "3.8"
+					"version": "3.9"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/python-38:latest"
+					"name": "registry.redhat.io/ubi8/python-39:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -167,20 +77,19 @@
 				}
 			},
 			{
-				"name": "3.8",
+				"name": "3.11-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.8 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+					"description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.8",
+					"openshift.io/display-name": "Python 3.11 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
-					"tags": "builder,python,hidden",
-					"version": "3.8"
+					"tags": "builder,python",
+					"version": "3.11"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/python-38-rhel7:latest"
+					"name": "registry.redhat.io/ubi8/python-311:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -189,20 +98,19 @@
 				}
 			},
 			{
-				"name": "3.6-ubi8",
+				"name": "3.12-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
+					"description": "Build and run Python 3.12 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.6 (UBI 8)",
+					"openshift.io/display-name": "Python 3.12 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.6,python",
 					"tags": "builder,python",
-					"version": "3.6"
+					"version": "3.12"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-36:latest"
+					"name": "registry.redhat.io/ubi8/python-312:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -211,20 +119,82 @@
 				}
 			},
 			{
-				"name": "2.7-ubi8",
+				"name": "3.9-ubi9",
 				"annotations": {
-					"description": "Build and run Python 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
+					"description": "Build and run Python 3.9 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 2.7 (UBI 8)",
+					"openshift.io/display-name": "Python 3.9 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:2.7,python",
 					"tags": "builder,python",
-					"version": "2.7"
+					"version": "3.9"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-27:latest"
+					"name": "registry.redhat.io/ubi9/python-39:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.11-ubi9",
+				"annotations": {
+					"description": "Build and run Python 3.11 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.11 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.11"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/python-311:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.12-ubi9",
+				"annotations": {
+					"description": "Build and run Python 3.12 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.12 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.12"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/python-312:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.11 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.11"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "3.11-ubi8"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-ppc64le/rails/templates/rails-pgsql-persistent.json
+++ b/assets/operator/ocp-ppc64le/rails/templates/rails-pgsql-persistent.json
@@ -7,13 +7,12 @@
 		"annotations": {
 			"description": "An example Rails application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
 			"iconClass": "icon-ruby",
-			"openshift.io/display-name": "Rails + PostgreSQL",
-			"openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
-			"openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.",
-			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"openshift.io/support-url": "https://access.redhat.com",
+			"openshift.io/display-name": "Rails + PostgreSQL (Persistent)",
 			"tags": "quickstart,ruby,rails",
-			"template.openshift.io/bindable": "false"
+			"template.openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
+			"template.openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.",
+			"template.openshift.io/provider-display-name": "Red Hat, Inc.",
+			"template.openshift.io/support-url": "https://access.redhat.com"
 		}
 	},
 	"message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
@@ -22,6 +21,10 @@
 			"apiVersion": "v1",
 			"kind": "Secret",
 			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-password": "{.data['application-password']}",
+					"template.openshift.io/expose-username": "{.data['application-user']}"
+				},
 				"name": "${NAME}"
 			},
 			"stringData": {
@@ -59,6 +62,9 @@
 			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-uri": "http://{.spec.host}{.spec.path}"
+				},
 				"name": "${NAME}"
 			},
 			"spec": {
@@ -96,9 +102,6 @@
 						"name": "${NAME}:latest"
 					}
 				},
-				"postCommit": {
-					"script": "bundle exec rake test"
-				},
 				"source": {
 					"contextDir": "${CONTEXT_DIR}",
 					"git": {
@@ -117,7 +120,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:${RUBY_VERSION}",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -140,11 +143,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"},{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.initContainers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -152,20 +156,11 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
-					"recreateParams": {
-						"pre": {
-							"execNewPod": {
-								"command": [
-									"./migrate-database.sh"
-								],
-								"containerName": "${NAME}"
-							},
-							"failurePolicy": "Abort"
-						}
-					},
 					"type": "Recreate"
 				},
 				"template": {
@@ -278,27 +273,89 @@
 									}
 								}
 							}
+						],
+						"initContainers": [
+							{
+								"command": [
+									"./migrate-database.sh"
+								],
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "SECRET_KEY_BASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "keybase",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									},
+									{
+										"name": "APPLICATION_DOMAIN",
+										"value": "${APPLICATION_DOMAIN}"
+									},
+									{
+										"name": "APPLICATION_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "APPLICATION_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "RAILS_ENV",
+										"value": "${RAILS_ENV}"
+									}
+								],
+								"image": " ",
+								"name": "ruby-init-container"
+							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -341,11 +398,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\", \"namespace\": \"openshift\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -353,7 +411,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -448,26 +508,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],
@@ -484,6 +525,20 @@
 			"displayName": "Namespace",
 			"description": "The OpenShift Namespace where the ImageStream resides.",
 			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "RUBY_VERSION",
+			"displayName": "Ruby Version",
+			"description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+			"value": "3.1-ubi8",
+			"required": true
+		},
+		{
+			"name": "POSTGRESQL_VERSION",
+			"displayName": "Postgresql Version",
+			"description": "Version of Postgresql image to be used (12-el8 by default).",
+			"value": "12-el8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-ppc64le/rails/templates/rails-postgresql-example.json
+++ b/assets/operator/ocp-ppc64le/rails/templates/rails-postgresql-example.json
@@ -96,9 +96,6 @@
 						"name": "${NAME}:latest"
 					}
 				},
-				"postCommit": {
-					"script": "bundle exec rake test"
-				},
 				"source": {
 					"contextDir": "${CONTEXT_DIR}",
 					"git": {
@@ -117,7 +114,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:${RUBY_VERSION}",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -140,11 +137,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"},{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.initContainers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -152,7 +150,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
 					"recreateParams": {
@@ -278,27 +278,89 @@
 									}
 								}
 							}
+						],
+						"initContainers": [
+							{
+								"command": [
+									"./migrate-database.sh"
+								],
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "SECRET_KEY_BASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "keybase",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									},
+									{
+										"name": "APPLICATION_DOMAIN",
+										"value": "${APPLICATION_DOMAIN}"
+									},
+									{
+										"name": "APPLICATION_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "APPLICATION_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "RAILS_ENV",
+										"value": "${RAILS_ENV}"
+									}
+								],
+								"image": " ",
+								"name": "ruby-init-container"
+							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -324,11 +386,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:12-el8\", \"namespace\": \"openshift\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -336,7 +399,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -429,26 +494,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],
@@ -465,6 +511,13 @@
 			"displayName": "Namespace",
 			"description": "The OpenShift Namespace where the ImageStream resides.",
 			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "RUBY_VERSION",
+			"displayName": "Ruby Version",
+			"description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+			"value": "3.1-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-ppc64le/ruby/imagestreams/ruby-rhel.json
+++ b/assets/operator/ocp-ppc64le/ruby/imagestreams/ruby-rhel.json
@@ -14,63 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "2.5-ubi8",
 				"annotations": {
-					"description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.1/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+					"description": "Build and run Ruby 2.5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby (Latest)",
+					"openshift.io/display-name": "Ruby 2.5 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby",
-					"tags": "builder,ruby"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "3.1-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.1-ubi9",
-				"annotations": {
-					"description": "Build and run Ruby 3.1 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
-					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.1 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.1,ruby",
 					"tags": "builder,ruby",
-					"version": "3.1"
+					"version": "2.5"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/ruby-31:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.0-ubi9",
-				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
-					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
-					"tags": "builder,ruby",
-					"version": "3.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/ruby-30:latest"
+					"name": "registry.redhat.io/ubi8/ruby-25:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -86,7 +42,6 @@
 					"openshift.io/display-name": "Ruby 3.1 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.1,ruby",
 					"tags": "builder,ruby",
 					"version": "3.1"
 				},
@@ -101,20 +56,19 @@
 				}
 			},
 			{
-				"name": "3.0-ubi8",
+				"name": "3.3-ubi8",
 				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+					"description": "Build and run Ruby 3.3 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 8)",
+					"openshift.io/display-name": "Ruby 3.3 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
 					"tags": "builder,ruby",
-					"version": "3.0"
+					"version": "3.3"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/ruby-30:latest"
+					"name": "registry.redhat.io/ubi8/ruby-33:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -123,20 +77,19 @@
 				}
 			},
 			{
-				"name": "3.0-ubi7",
+				"name": "3.0-ubi9",
 				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+					"description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 7)",
+					"openshift.io/display-name": "Ruby 3.0 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
 					"tags": "builder,ruby",
 					"version": "3.0"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/ruby-30:latest"
+					"name": "registry.redhat.io/ubi9/ruby-30:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -145,20 +98,61 @@
 				}
 			},
 			{
-				"name": "2.5-ubi8",
+				"name": "3.1-ubi9",
 				"annotations": {
-					"description": "Build and run Ruby 2.5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
+					"description": "Build and run Ruby 3.1 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 2.5 (UBI 8)",
+					"openshift.io/display-name": "Ruby 3.1 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:2.5,ruby",
 					"tags": "builder,ruby",
-					"version": "2.5"
+					"version": "3.1"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/ruby-25:latest"
+					"name": "registry.redhat.io/ubi9/ruby-31:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.3-ubi9",
+				"annotations": {
+					"description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 3.3 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"tags": "builder,ruby",
+					"version": "3.3"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/ruby-33:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 3.3 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"tags": "builder,ruby",
+					"version": "3.3"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "3.3-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-s390x/dotnet/imagestreams/dotnet-rhel-s390x.json
+++ b/assets/operator/ocp-s390x/dotnet/imagestreams/dotnet-rhel-s390x.json
@@ -83,52 +83,6 @@
 				}
 			},
 			{
-				"name": "7.0-ubi8",
-				"annotations": {
-					"description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 (UBI 8)",
-					"sampleContextDir": "app",
-					"sampleRef": "dotnet-7.0",
-					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-					"supports": "dotnet:7.0,dotnet",
-					"tags": "builder,.net,dotnet,dotnetcore,dotnet70",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "7.0",
-				"annotations": {
-					"description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 (UBI 8)",
-					"sampleContextDir": "app",
-					"sampleRef": "dotnetcore-7.0",
-					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-					"supports": "dotnet:7.0,dotnet",
-					"tags": "builder,.net,dotnet,dotnetcore,dotnet70,hidden",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "6.0-ubi8",
 				"annotations": {
 					"description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",

--- a/assets/operator/ocp-s390x/dotnet/imagestreams/dotnet-runtime-rhel-s390x.json
+++ b/assets/operator/ocp-s390x/dotnet/imagestreams/dotnet-runtime-rhel-s390x.json
@@ -74,46 +74,6 @@
 				}
 			},
 			{
-				"name": "7.0-ubi8",
-				"annotations": {
-					"description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-					"supports": "dotnet-runtime",
-					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "7.0",
-				"annotations": {
-					"description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-					"supports": "dotnet-runtime",
-					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "6.0-ubi8",
 				"annotations": {
 					"description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",

--- a/assets/operator/ocp-s390x/httpd/imagestreams/httpd-rhel.json
+++ b/assets/operator/ocp-s390x/httpd/imagestreams/httpd-rhel.json
@@ -56,27 +56,6 @@
 				}
 			},
 			{
-				"name": "2.4-el7",
-				"annotations": {
-					"description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
-					"iconClass": "icon-httpd",
-					"openshift.io/display-name": "Apache HTTP Server 2.4 (RHEL 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/httpd-ex.git",
-					"tags": "builder,httpd",
-					"version": "2.4"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/httpd-24-rhel7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "2.4-el8",
 				"annotations": {
 					"description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",

--- a/assets/operator/ocp-s390x/nginx/imagestreams/nginx-rhel.json
+++ b/assets/operator/ocp-s390x/nginx/imagestreams/nginx-rhel.json
@@ -14,27 +14,6 @@
 		},
 		"tags": [
 			{
-				"name": "1.20-ubi7",
-				"annotations": {
-					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
-					"iconClass": "icon-nginx",
-					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-					"tags": "builder,nginx",
-					"version": "1.20"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/nginx-120:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "1.22-ubi8",
 				"annotations": {
 					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
@@ -98,19 +77,40 @@
 				}
 			},
 			{
-				"name": "latest",
+				"name": "1.24-ubi9",
 				"annotations": {
-					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.",
 					"iconClass": "icon-nginx",
-					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (Latest)",
+					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
 					"tags": "builder,nginx",
-					"version": "1.22"
+					"version": "1.24"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nginx-124:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-nginx",
+					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+					"tags": "builder,nginx",
+					"version": "1.24"
 				},
 				"from": {
 					"kind": "ImageStreamTag",
-					"name": "1.22-ubi8"
+					"name": "1.24-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-s390x/nodejs/imagestreams/nodejs-rhel.json
+++ b/assets/operator/ocp-s390x/nodejs/imagestreams/nodejs-rhel.json
@@ -14,53 +14,11 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "18-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+					"description": "Build and run Node.js 18 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js (Latest)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"supports": "nodejs",
-					"tags": "builder,nodejs"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "20-ubi9"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "20-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "20"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-20:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "18-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 9)",
+					"openshift.io/display-name": "Node.js 18 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
@@ -68,7 +26,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-18:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-18:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -77,82 +35,19 @@
 				}
 			},
 			{
-				"name": "20-ubi9-minimal",
+				"name": "18-minimal-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 9 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "20"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "18-ubi9-minimal",
-				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 9 Minimal)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "18"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "16-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "16"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-16:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "16-ubi9-minimal",
-				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 9 Minimal)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "16"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-16-minimal:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -182,15 +77,15 @@
 				}
 			},
 			{
-				"name": "20-ubi8-minimal",
+				"name": "20-minimal-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "20"
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
@@ -203,11 +98,11 @@
 				}
 			},
 			{
-				"name": "18-ubi8",
+				"name": "18-ubi9",
 				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
+					"description": "Build and run Node.js 18 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 8)",
+					"openshift.io/display-name": "Node.js 18 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
@@ -215,7 +110,70 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-18:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-18:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "18-minimal-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 18-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "18-minimal"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "20-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-20:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "20-minimal-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 20-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20-minimal"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -226,13 +184,13 @@
 			{
 				"name": "18-ubi8-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "18"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
@@ -245,19 +203,19 @@
 				}
 			},
 			{
-				"name": "16-ubi8",
+				"name": "20-ubi8-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 8)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-16:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-20-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -266,19 +224,19 @@
 				}
 			},
 			{
-				"name": "16-ubi8-minimal",
+				"name": "18-ubi9-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-16-minimal:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -287,19 +245,40 @@
 				}
 			},
 			{
-				"name": "14-ubi7",
+				"name": "20-ubi9-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 14 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 14 (UBI 7)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs,hidden",
-					"version": "14"
+					"tags": "builder,nodejs",
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/nodejs-14:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "20-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-s390x/nodejs/templates/nodejs-postgresql-example.json
+++ b/assets/operator/ocp-s390x/nodejs/templates/nodejs-postgresql-example.json
@@ -422,8 +422,8 @@
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-			"value": "16-ubi8",
+			"description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+			"value": "18-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-s390x/nodejs/templates/nodejs-postgresql-persistent.json
+++ b/assets/operator/ocp-s390x/nodejs/templates/nodejs-postgresql-persistent.json
@@ -439,8 +439,8 @@
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-			"value": "16-ubi8",
+			"description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+			"value": "18-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-s390x/perl/imagestreams/perl-rhel.json
+++ b/assets/operator/ocp-s390x/perl/imagestreams/perl-rhel.json
@@ -14,41 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "5.26-ubi8",
 				"annotations": {
-					"description": "Build and run Perl applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Perl available on OpenShift, including major version updates.",
+					"description": "Build and run Perl 5.26 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl (Latest)",
+					"openshift.io/display-name": "Perl 5.26 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl",
-					"tags": "builder,perl"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "5.32-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "5.32-ubi9",
-				"annotations": {
-					"description": "Build and run Perl 5.32 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
-					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.32 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.32,perl",
 					"tags": "builder,perl",
-					"version": "5.32"
+					"version": "5.26"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/perl-532:latest"
+					"name": "registry.redhat.io/ubi8/perl-526:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -64,7 +42,6 @@
 					"openshift.io/display-name": "Perl 5.32 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.32,perl",
 					"tags": "builder,perl",
 					"version": "5.32"
 				},
@@ -79,20 +56,19 @@
 				}
 			},
 			{
-				"name": "5.30-el7",
+				"name": "5.32-ubi9",
 				"annotations": {
-					"description": "Build and run Perl 5.30 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
+					"description": "Build and run Perl 5.32 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.30 (RHEL 7)",
+					"openshift.io/display-name": "Perl 5.32 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.30,perl",
 					"tags": "builder,perl",
-					"version": "5.30"
+					"version": "5.32"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/perl-530-rhel7:latest"
+					"name": "registry.redhat.io/ubi9/perl-532:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -101,42 +77,19 @@
 				}
 			},
 			{
-				"name": "5.30",
+				"name": "latest",
 				"annotations": {
-					"description": "Build and run Perl 5.30 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
+					"description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.30",
+					"openshift.io/display-name": "Perl 5.32 (Latest)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.30,perl",
-					"tags": "builder,perl,hidden",
-					"version": "5.30"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/perl-530-rhel7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "5.26-ubi8",
-				"annotations": {
-					"description": "Build and run Perl 5.26 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26-mod_fcgid/README.md.",
-					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.26 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.26,perl",
 					"tags": "builder,perl",
-					"version": "5.26"
+					"version": "5.32"
 				},
 				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/perl-526:latest"
+					"kind": "ImageStreamTag",
+					"name": "5.32-ubi8"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-s390x/php/imagestreams/php-rhel.json
+++ b/assets/operator/ocp-s390x/php/imagestreams/php-rhel.json
@@ -14,27 +14,6 @@
 		},
 		"tags": [
 			{
-				"name": "7.3-ubi7",
-				"annotations": {
-					"description": "Build and run PHP 7.3 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.",
-					"iconClass": "icon-php",
-					"openshift.io/display-name": "PHP 7.3 (UBI 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
-					"tags": "builder,php",
-					"version": "7.3"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/php-73:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "7.4-ubi8",
 				"annotations": {
 					"description": "Build and run PHP 7.4 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.4/README.md.",
@@ -77,6 +56,27 @@
 				}
 			},
 			{
+				"name": "8.2-ubi8",
+				"annotations": {
+					"description": "Build and run PHP 8.2 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+					"iconClass": "icon-php",
+					"openshift.io/display-name": "PHP 8.2 (UBI 8)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
+					"tags": "builder,php",
+					"version": "8.2"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8/php-82:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
 				"name": "8.0-ubi9",
 				"annotations": {
 					"description": "Build and run PHP 8.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.0/README.md.",
@@ -111,6 +111,27 @@
 				"from": {
 					"kind": "DockerImage",
 					"name": "registry.redhat.io/ubi9/php-81:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "8.2-ubi9",
+				"annotations": {
+					"description": "Build and run PHP 8.2 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+					"iconClass": "icon-php",
+					"openshift.io/display-name": "PHP 8.2 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
+					"tags": "builder,php",
+					"version": "8.2"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/php-82:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-s390x/python/imagestreams/python-rhel.json
+++ b/assets/operator/ocp-s390x/python/imagestreams/python-rhel.json
@@ -14,107 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "3.6-ubi8",
 				"annotations": {
-					"description": "Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.",
+					"description": "Build and run Python 3.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python (Latest)",
+					"openshift.io/display-name": "Python 3.6 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python",
-					"tags": "builder,python"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "3.11-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.11-ubi9",
-				"annotations": {
-					"description": "Build and run Python 3.11 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.11 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.11,python",
 					"tags": "builder,python",
-					"version": "3.11"
+					"version": "3.6"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/python-311:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.11-ubi8",
-				"annotations": {
-					"description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.11 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.11,python",
-					"tags": "builder,python",
-					"version": "3.11"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-311:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.9-ubi9",
-				"annotations": {
-					"description": "Build and run Python 3.9 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.9 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.9,python",
-					"tags": "builder,python",
-					"version": "3.9"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/python-39:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.9-ubi8",
-				"annotations": {
-					"description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.9 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.9,python",
-					"tags": "builder,python",
-					"version": "3.9"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-39:latest"
+					"name": "registry.redhat.io/ubi8/python-36:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -130,7 +42,6 @@
 					"openshift.io/display-name": "Python 3.8 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
 					"tags": "builder,python",
 					"version": "3.8"
 				},
@@ -145,20 +56,19 @@
 				}
 			},
 			{
-				"name": "3.8-ubi7",
+				"name": "3.9-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.8 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+					"description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.8 (UBI 7)",
+					"openshift.io/display-name": "Python 3.9 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
 					"tags": "builder,python",
-					"version": "3.8"
+					"version": "3.9"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/python-38:latest"
+					"name": "registry.redhat.io/ubi8/python-39:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -167,20 +77,19 @@
 				}
 			},
 			{
-				"name": "3.8",
+				"name": "3.11-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.8 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+					"description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.8",
+					"openshift.io/display-name": "Python 3.11 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
-					"tags": "builder,python,hidden",
-					"version": "3.8"
+					"tags": "builder,python",
+					"version": "3.11"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/python-38-rhel7:latest"
+					"name": "registry.redhat.io/ubi8/python-311:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -189,20 +98,19 @@
 				}
 			},
 			{
-				"name": "3.6-ubi8",
+				"name": "3.12-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
+					"description": "Build and run Python 3.12 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.6 (UBI 8)",
+					"openshift.io/display-name": "Python 3.12 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.6,python",
 					"tags": "builder,python",
-					"version": "3.6"
+					"version": "3.12"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-36:latest"
+					"name": "registry.redhat.io/ubi8/python-312:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -211,20 +119,82 @@
 				}
 			},
 			{
-				"name": "2.7-ubi8",
+				"name": "3.9-ubi9",
 				"annotations": {
-					"description": "Build and run Python 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
+					"description": "Build and run Python 3.9 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 2.7 (UBI 8)",
+					"openshift.io/display-name": "Python 3.9 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:2.7,python",
 					"tags": "builder,python",
-					"version": "2.7"
+					"version": "3.9"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-27:latest"
+					"name": "registry.redhat.io/ubi9/python-39:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.11-ubi9",
+				"annotations": {
+					"description": "Build and run Python 3.11 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.11 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.11"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/python-311:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.12-ubi9",
+				"annotations": {
+					"description": "Build and run Python 3.12 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.12 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.12"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/python-312:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.11 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.11"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "3.11-ubi8"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-s390x/rails/templates/rails-pgsql-persistent.json
+++ b/assets/operator/ocp-s390x/rails/templates/rails-pgsql-persistent.json
@@ -7,13 +7,12 @@
 		"annotations": {
 			"description": "An example Rails application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
 			"iconClass": "icon-ruby",
-			"openshift.io/display-name": "Rails + PostgreSQL",
-			"openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
-			"openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.",
-			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"openshift.io/support-url": "https://access.redhat.com",
+			"openshift.io/display-name": "Rails + PostgreSQL (Persistent)",
 			"tags": "quickstart,ruby,rails",
-			"template.openshift.io/bindable": "false"
+			"template.openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
+			"template.openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.",
+			"template.openshift.io/provider-display-name": "Red Hat, Inc.",
+			"template.openshift.io/support-url": "https://access.redhat.com"
 		}
 	},
 	"message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
@@ -22,6 +21,10 @@
 			"apiVersion": "v1",
 			"kind": "Secret",
 			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-password": "{.data['application-password']}",
+					"template.openshift.io/expose-username": "{.data['application-user']}"
+				},
 				"name": "${NAME}"
 			},
 			"stringData": {
@@ -59,6 +62,9 @@
 			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-uri": "http://{.spec.host}{.spec.path}"
+				},
 				"name": "${NAME}"
 			},
 			"spec": {
@@ -96,9 +102,6 @@
 						"name": "${NAME}:latest"
 					}
 				},
-				"postCommit": {
-					"script": "bundle exec rake test"
-				},
 				"source": {
 					"contextDir": "${CONTEXT_DIR}",
 					"git": {
@@ -117,7 +120,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:${RUBY_VERSION}",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -140,11 +143,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"},{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.initContainers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -152,20 +156,11 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
-					"recreateParams": {
-						"pre": {
-							"execNewPod": {
-								"command": [
-									"./migrate-database.sh"
-								],
-								"containerName": "${NAME}"
-							},
-							"failurePolicy": "Abort"
-						}
-					},
 					"type": "Recreate"
 				},
 				"template": {
@@ -278,27 +273,89 @@
 									}
 								}
 							}
+						],
+						"initContainers": [
+							{
+								"command": [
+									"./migrate-database.sh"
+								],
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "SECRET_KEY_BASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "keybase",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									},
+									{
+										"name": "APPLICATION_DOMAIN",
+										"value": "${APPLICATION_DOMAIN}"
+									},
+									{
+										"name": "APPLICATION_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "APPLICATION_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "RAILS_ENV",
+										"value": "${RAILS_ENV}"
+									}
+								],
+								"image": " ",
+								"name": "ruby-init-container"
+							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -341,11 +398,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\", \"namespace\": \"openshift\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -353,7 +411,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -448,26 +508,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],
@@ -484,6 +525,20 @@
 			"displayName": "Namespace",
 			"description": "The OpenShift Namespace where the ImageStream resides.",
 			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "RUBY_VERSION",
+			"displayName": "Ruby Version",
+			"description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+			"value": "3.1-ubi8",
+			"required": true
+		},
+		{
+			"name": "POSTGRESQL_VERSION",
+			"displayName": "Postgresql Version",
+			"description": "Version of Postgresql image to be used (12-el8 by default).",
+			"value": "12-el8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-s390x/rails/templates/rails-postgresql-example.json
+++ b/assets/operator/ocp-s390x/rails/templates/rails-postgresql-example.json
@@ -96,9 +96,6 @@
 						"name": "${NAME}:latest"
 					}
 				},
-				"postCommit": {
-					"script": "bundle exec rake test"
-				},
 				"source": {
 					"contextDir": "${CONTEXT_DIR}",
 					"git": {
@@ -117,7 +114,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:${RUBY_VERSION}",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -140,11 +137,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"},{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.initContainers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -152,7 +150,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
 					"recreateParams": {
@@ -278,27 +278,89 @@
 									}
 								}
 							}
+						],
+						"initContainers": [
+							{
+								"command": [
+									"./migrate-database.sh"
+								],
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "SECRET_KEY_BASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "keybase",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									},
+									{
+										"name": "APPLICATION_DOMAIN",
+										"value": "${APPLICATION_DOMAIN}"
+									},
+									{
+										"name": "APPLICATION_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "APPLICATION_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "RAILS_ENV",
+										"value": "${RAILS_ENV}"
+									}
+								],
+								"image": " ",
+								"name": "ruby-init-container"
+							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -324,11 +386,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:12-el8\", \"namespace\": \"openshift\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -336,7 +399,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -429,26 +494,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],
@@ -465,6 +511,13 @@
 			"displayName": "Namespace",
 			"description": "The OpenShift Namespace where the ImageStream resides.",
 			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "RUBY_VERSION",
+			"displayName": "Ruby Version",
+			"description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+			"value": "3.1-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-s390x/ruby/imagestreams/ruby-rhel.json
+++ b/assets/operator/ocp-s390x/ruby/imagestreams/ruby-rhel.json
@@ -14,63 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "2.5-ubi8",
 				"annotations": {
-					"description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.1/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+					"description": "Build and run Ruby 2.5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby (Latest)",
+					"openshift.io/display-name": "Ruby 2.5 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby",
-					"tags": "builder,ruby"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "3.1-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.1-ubi9",
-				"annotations": {
-					"description": "Build and run Ruby 3.1 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
-					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.1 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.1,ruby",
 					"tags": "builder,ruby",
-					"version": "3.1"
+					"version": "2.5"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/ruby-31:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.0-ubi9",
-				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
-					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
-					"tags": "builder,ruby",
-					"version": "3.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/ruby-30:latest"
+					"name": "registry.redhat.io/ubi8/ruby-25:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -86,7 +42,6 @@
 					"openshift.io/display-name": "Ruby 3.1 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.1,ruby",
 					"tags": "builder,ruby",
 					"version": "3.1"
 				},
@@ -101,20 +56,19 @@
 				}
 			},
 			{
-				"name": "3.0-ubi8",
+				"name": "3.3-ubi8",
 				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+					"description": "Build and run Ruby 3.3 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 8)",
+					"openshift.io/display-name": "Ruby 3.3 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
 					"tags": "builder,ruby",
-					"version": "3.0"
+					"version": "3.3"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/ruby-30:latest"
+					"name": "registry.redhat.io/ubi8/ruby-33:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -123,20 +77,19 @@
 				}
 			},
 			{
-				"name": "3.0-ubi7",
+				"name": "3.0-ubi9",
 				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+					"description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 7)",
+					"openshift.io/display-name": "Ruby 3.0 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
 					"tags": "builder,ruby",
 					"version": "3.0"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/ruby-30:latest"
+					"name": "registry.redhat.io/ubi9/ruby-30:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -145,20 +98,61 @@
 				}
 			},
 			{
-				"name": "2.5-ubi8",
+				"name": "3.1-ubi9",
 				"annotations": {
-					"description": "Build and run Ruby 2.5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
+					"description": "Build and run Ruby 3.1 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 2.5 (UBI 8)",
+					"openshift.io/display-name": "Ruby 3.1 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:2.5,ruby",
 					"tags": "builder,ruby",
-					"version": "2.5"
+					"version": "3.1"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/ruby-25:latest"
+					"name": "registry.redhat.io/ubi9/ruby-31:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.3-ubi9",
+				"annotations": {
+					"description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 3.3 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"tags": "builder,ruby",
+					"version": "3.3"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/ruby-33:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 3.3 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"tags": "builder,ruby",
+					"version": "3.3"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "3.3-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-x86_64/dotnet/imagestreams/dotnet-rhel.json
+++ b/assets/operator/ocp-x86_64/dotnet/imagestreams/dotnet-rhel.json
@@ -83,52 +83,6 @@
 				}
 			},
 			{
-				"name": "7.0-ubi8",
-				"annotations": {
-					"description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 (UBI 8)",
-					"sampleContextDir": "app",
-					"sampleRef": "dotnet-7.0",
-					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-					"supports": "dotnet:7.0,dotnet",
-					"tags": "builder,.net,dotnet,dotnetcore,dotnet70",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "7.0",
-				"annotations": {
-					"description": "Build and run .NET 7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/build/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 (UBI 8)",
-					"sampleContextDir": "app",
-					"sampleRef": "dotnetcore-7.0",
-					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
-					"supports": "dotnet:7.0,dotnet",
-					"tags": "builder,.net,dotnet,dotnetcore,dotnet70,hidden",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "6.0-ubi8",
 				"annotations": {
 					"description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/build/README.md.",

--- a/assets/operator/ocp-x86_64/dotnet/imagestreams/dotnet-runtime-rhel.json
+++ b/assets/operator/ocp-x86_64/dotnet/imagestreams/dotnet-runtime-rhel.json
@@ -74,46 +74,6 @@
 				}
 			},
 			{
-				"name": "7.0-ubi8",
-				"annotations": {
-					"description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-					"supports": "dotnet-runtime",
-					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "7.0",
-				"annotations": {
-					"description": "Run .NET 7 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/7.0/runtime/README.md.",
-					"iconClass": "icon-dotnet",
-					"openshift.io/display-name": ".NET 7 Runtime (UBI 8)",
-					"supports": "dotnet-runtime",
-					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
-					"version": "7.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.access.redhat.com/ubi8/dotnet-70-runtime:7.0"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "6.0-ubi8",
 				"annotations": {
 					"description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/main/6.0/runtime/README.md.",

--- a/assets/operator/ocp-x86_64/httpd/imagestreams/httpd-rhel.json
+++ b/assets/operator/ocp-x86_64/httpd/imagestreams/httpd-rhel.json
@@ -56,27 +56,6 @@
 				}
 			},
 			{
-				"name": "2.4-el7",
-				"annotations": {
-					"description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
-					"iconClass": "icon-httpd",
-					"openshift.io/display-name": "Apache HTTP Server 2.4 (RHEL 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/httpd-ex.git",
-					"tags": "builder,httpd",
-					"version": "2.4"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/httpd-24-rhel7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "2.4-el8",
 				"annotations": {
 					"description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",

--- a/assets/operator/ocp-x86_64/nginx/imagestreams/nginx-rhel.json
+++ b/assets/operator/ocp-x86_64/nginx/imagestreams/nginx-rhel.json
@@ -14,27 +14,6 @@
 		},
 		"tags": [
 			{
-				"name": "1.20-ubi7",
-				"annotations": {
-					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
-					"iconClass": "icon-nginx",
-					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-					"tags": "builder,nginx",
-					"version": "1.20"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/nginx-120:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "1.22-ubi8",
 				"annotations": {
 					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
@@ -98,19 +77,40 @@
 				}
 			},
 			{
-				"name": "latest",
+				"name": "1.24-ubi9",
 				"annotations": {
-					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.",
 					"iconClass": "icon-nginx",
-					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (Latest)",
+					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
 					"tags": "builder,nginx",
-					"version": "1.22"
+					"version": "1.24"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nginx-124:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-nginx",
+					"openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+					"tags": "builder,nginx",
+					"version": "1.24"
 				},
 				"from": {
 					"kind": "ImageStreamTag",
-					"name": "1.22-ubi8"
+					"name": "1.24-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-x86_64/nodejs/imagestreams/nodejs-rhel.json
+++ b/assets/operator/ocp-x86_64/nodejs/imagestreams/nodejs-rhel.json
@@ -14,53 +14,11 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "18-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+					"description": "Build and run Node.js 18 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js (Latest)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"supports": "nodejs",
-					"tags": "builder,nodejs"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "20-ubi9"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "20-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "20"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-20:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "18-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 9)",
+					"openshift.io/display-name": "Node.js 18 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
@@ -68,7 +26,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-18:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-18:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -77,82 +35,19 @@
 				}
 			},
 			{
-				"name": "20-ubi9-minimal",
+				"name": "18-minimal-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 9 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "20"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "18-ubi9-minimal",
-				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 9 Minimal)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "18"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "16-ubi9",
-				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "16"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-16:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "16-ubi9-minimal",
-				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 9 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
-					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 9 Minimal)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs",
-					"version": "16"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/nodejs-16-minimal:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -182,15 +77,15 @@
 				}
 			},
 			{
-				"name": "20-ubi8-minimal",
+				"name": "20-minimal-ubi8",
 				"annotations": {
-					"description": "Build and run Node.js 20 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 20 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "20"
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
@@ -203,11 +98,11 @@
 				}
 			},
 			{
-				"name": "18-ubi8",
+				"name": "18-ubi9",
 				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
+					"description": "Build and run Node.js 18 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 8)",
+					"openshift.io/display-name": "Node.js 18 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
@@ -215,7 +110,70 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-18:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-18:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "18-minimal-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 18-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "18-minimal"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "20-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-20:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "20-minimal-ubi9",
+				"annotations": {
+					"description": "Build and run Node.js 20-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20-minimal"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -226,13 +184,13 @@
 			{
 				"name": "18-ubi8-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 18 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 18 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "18"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
@@ -245,19 +203,19 @@
 				}
 			},
 			{
-				"name": "16-ubi8",
+				"name": "20-ubi8-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 8)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-16:latest"
+					"name": "registry.redhat.io/ubi8/nodejs-20-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -266,19 +224,19 @@
 				}
 			},
 			{
-				"name": "16-ubi8-minimal",
+				"name": "18-ubi9-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 16 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+					"description": "Build and run Node.js 18-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 16 (UBI 8 Minimal)",
+					"openshift.io/display-name": "Node.js 18-minimal (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
 					"tags": "builder,nodejs",
-					"version": "16"
+					"version": "18-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/nodejs-16-minimal:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-18-minimal:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -287,19 +245,40 @@
 				}
 			},
 			{
-				"name": "14-ubi7",
+				"name": "20-ubi9-minimal",
 				"annotations": {
-					"description": "Build and run Node.js 14 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+					"description": "Build and run Node.js 20-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20-minimal/README.md.",
 					"iconClass": "icon-nodejs",
-					"openshift.io/display-name": "Node.js 14 (UBI 7)",
+					"openshift.io/display-name": "Node.js 20-minimal (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
-					"tags": "builder,nodejs,hidden",
-					"version": "14"
+					"tags": "builder,nodejs",
+					"version": "20-minimal"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/nodejs-14:latest"
+					"name": "registry.redhat.io/ubi9/nodejs-20-minimal:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-nodejs",
+					"openshift.io/display-name": "Node.js 20 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+					"tags": "builder,nodejs",
+					"version": "20"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "20-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-x86_64/nodejs/templates/nodejs-postgresql-example.json
+++ b/assets/operator/ocp-x86_64/nodejs/templates/nodejs-postgresql-example.json
@@ -422,8 +422,8 @@
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-			"value": "16-ubi8",
+			"description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+			"value": "18-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-x86_64/nodejs/templates/nodejs-postgresql-persistent.json
+++ b/assets/operator/ocp-x86_64/nodejs/templates/nodejs-postgresql-persistent.json
@@ -439,8 +439,8 @@
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-			"value": "16-ubi8",
+			"description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+			"value": "18-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-x86_64/perl/imagestreams/perl-rhel.json
+++ b/assets/operator/ocp-x86_64/perl/imagestreams/perl-rhel.json
@@ -14,41 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "5.26-ubi8",
 				"annotations": {
-					"description": "Build and run Perl applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Perl available on OpenShift, including major version updates.",
+					"description": "Build and run Perl 5.26 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl (Latest)",
+					"openshift.io/display-name": "Perl 5.26 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl",
-					"tags": "builder,perl"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "5.32-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "5.32-ubi9",
-				"annotations": {
-					"description": "Build and run Perl 5.32 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
-					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.32 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.32,perl",
 					"tags": "builder,perl",
-					"version": "5.32"
+					"version": "5.26"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/perl-532:latest"
+					"name": "registry.redhat.io/ubi8/perl-526:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -64,7 +42,6 @@
 					"openshift.io/display-name": "Perl 5.32 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.32,perl",
 					"tags": "builder,perl",
 					"version": "5.32"
 				},
@@ -79,20 +56,19 @@
 				}
 			},
 			{
-				"name": "5.30-el7",
+				"name": "5.32-ubi9",
 				"annotations": {
-					"description": "Build and run Perl 5.30 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
+					"description": "Build and run Perl 5.32 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.30 (RHEL 7)",
+					"openshift.io/display-name": "Perl 5.32 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.30,perl",
 					"tags": "builder,perl",
-					"version": "5.30"
+					"version": "5.32"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/perl-530-rhel7:latest"
+					"name": "registry.redhat.io/ubi9/perl-532:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -101,42 +77,19 @@
 				}
 			},
 			{
-				"name": "5.30",
+				"name": "latest",
 				"annotations": {
-					"description": "Build and run Perl 5.30 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
+					"description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
 					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.30",
+					"openshift.io/display-name": "Perl 5.32 (Latest)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.30,perl",
-					"tags": "builder,perl,hidden",
-					"version": "5.30"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/perl-530-rhel7:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "5.26-ubi8",
-				"annotations": {
-					"description": "Build and run Perl 5.26 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26-mod_fcgid/README.md.",
-					"iconClass": "icon-perl",
-					"openshift.io/display-name": "Perl 5.26 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
-					"supports": "perl:5.26,perl",
 					"tags": "builder,perl",
-					"version": "5.26"
+					"version": "5.32"
 				},
 				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/perl-526:latest"
+					"kind": "ImageStreamTag",
+					"name": "5.32-ubi8"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-x86_64/php/imagestreams/php-rhel.json
+++ b/assets/operator/ocp-x86_64/php/imagestreams/php-rhel.json
@@ -14,27 +14,6 @@
 		},
 		"tags": [
 			{
-				"name": "7.3-ubi7",
-				"annotations": {
-					"description": "Build and run PHP 7.3 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.3/README.md.",
-					"iconClass": "icon-php",
-					"openshift.io/display-name": "PHP 7.3 (UBI 7)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
-					"tags": "builder,php",
-					"version": "7.3"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/php-73:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
 				"name": "7.4-ubi8",
 				"annotations": {
 					"description": "Build and run PHP 7.4 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/7.4/README.md.",
@@ -77,6 +56,27 @@
 				}
 			},
 			{
+				"name": "8.2-ubi8",
+				"annotations": {
+					"description": "Build and run PHP 8.2 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+					"iconClass": "icon-php",
+					"openshift.io/display-name": "PHP 8.2 (UBI 8)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
+					"tags": "builder,php",
+					"version": "8.2"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi8/php-82:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
 				"name": "8.0-ubi9",
 				"annotations": {
 					"description": "Build and run PHP 8.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.0/README.md.",
@@ -111,6 +111,27 @@
 				"from": {
 					"kind": "DockerImage",
 					"name": "registry.redhat.io/ubi9/php-81:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "8.2-ubi9",
+				"annotations": {
+					"description": "Build and run PHP 8.2 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/8.2/README.md.",
+					"iconClass": "icon-php",
+					"openshift.io/display-name": "PHP 8.2 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/cakephp-ex.git",
+					"tags": "builder,php",
+					"version": "8.2"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/php-82:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-x86_64/python/imagestreams/python-rhel.json
+++ b/assets/operator/ocp-x86_64/python/imagestreams/python-rhel.json
@@ -14,107 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "3.6-ubi8",
 				"annotations": {
-					"description": "Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.",
+					"description": "Build and run Python 3.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python (Latest)",
+					"openshift.io/display-name": "Python 3.6 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python",
-					"tags": "builder,python"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "3.11-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.11-ubi9",
-				"annotations": {
-					"description": "Build and run Python 3.11 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.11 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.11,python",
 					"tags": "builder,python",
-					"version": "3.11"
+					"version": "3.6"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/python-311:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.11-ubi8",
-				"annotations": {
-					"description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.11 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.11,python",
-					"tags": "builder,python",
-					"version": "3.11"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-311:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.9-ubi9",
-				"annotations": {
-					"description": "Build and run Python 3.9 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.9 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.9,python",
-					"tags": "builder,python",
-					"version": "3.9"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/python-39:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.9-ubi8",
-				"annotations": {
-					"description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
-					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.9 (UBI 8)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.9,python",
-					"tags": "builder,python",
-					"version": "3.9"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-39:latest"
+					"name": "registry.redhat.io/ubi8/python-36:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -130,7 +42,6 @@
 					"openshift.io/display-name": "Python 3.8 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
 					"tags": "builder,python",
 					"version": "3.8"
 				},
@@ -145,20 +56,19 @@
 				}
 			},
 			{
-				"name": "3.8-ubi7",
+				"name": "3.9-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.8 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+					"description": "Build and run Python 3.9 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.8 (UBI 7)",
+					"openshift.io/display-name": "Python 3.9 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
 					"tags": "builder,python",
-					"version": "3.8"
+					"version": "3.9"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/python-38:latest"
+					"name": "registry.redhat.io/ubi8/python-39:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -167,20 +77,19 @@
 				}
 			},
 			{
-				"name": "3.8",
+				"name": "3.11-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.8 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+					"description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.8",
+					"openshift.io/display-name": "Python 3.11 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.8,python",
-					"tags": "builder,python,hidden",
-					"version": "3.8"
+					"tags": "builder,python",
+					"version": "3.11"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/rhscl/python-38-rhel7:latest"
+					"name": "registry.redhat.io/ubi8/python-311:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -189,20 +98,19 @@
 				}
 			},
 			{
-				"name": "3.6-ubi8",
+				"name": "3.12-ubi8",
 				"annotations": {
-					"description": "Build and run Python 3.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
+					"description": "Build and run Python 3.12 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 3.6 (UBI 8)",
+					"openshift.io/display-name": "Python 3.12 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:3.6,python",
 					"tags": "builder,python",
-					"version": "3.6"
+					"version": "3.12"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-36:latest"
+					"name": "registry.redhat.io/ubi8/python-312:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -211,20 +119,82 @@
 				}
 			},
 			{
-				"name": "2.7-ubi8",
+				"name": "3.9-ubi9",
 				"annotations": {
-					"description": "Build and run Python 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
+					"description": "Build and run Python 3.9 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.",
 					"iconClass": "icon-python",
-					"openshift.io/display-name": "Python 2.7 (UBI 8)",
+					"openshift.io/display-name": "Python 3.9 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/django-ex.git",
-					"supports": "python:2.7,python",
 					"tags": "builder,python",
-					"version": "2.7"
+					"version": "3.9"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/python-27:latest"
+					"name": "registry.redhat.io/ubi9/python-39:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.11-ubi9",
+				"annotations": {
+					"description": "Build and run Python 3.11 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.11 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.11"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/python-311:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.12-ubi9",
+				"annotations": {
+					"description": "Build and run Python 3.12 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.12/README.md.",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.12 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.12"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/python-312:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-python",
+					"openshift.io/display-name": "Python 3.11 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/django-ex.git",
+					"tags": "builder,python",
+					"version": "3.11"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "3.11-ubi8"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/assets/operator/ocp-x86_64/rails/templates/rails-pgsql-persistent.json
+++ b/assets/operator/ocp-x86_64/rails/templates/rails-pgsql-persistent.json
@@ -7,13 +7,12 @@
 		"annotations": {
 			"description": "An example Rails application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
 			"iconClass": "icon-ruby",
-			"openshift.io/display-name": "Rails + PostgreSQL",
-			"openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
-			"openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.",
-			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"openshift.io/support-url": "https://access.redhat.com",
+			"openshift.io/display-name": "Rails + PostgreSQL (Persistent)",
 			"tags": "quickstart,ruby,rails",
-			"template.openshift.io/bindable": "false"
+			"template.openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
+			"template.openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.",
+			"template.openshift.io/provider-display-name": "Red Hat, Inc.",
+			"template.openshift.io/support-url": "https://access.redhat.com"
 		}
 	},
 	"message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
@@ -22,6 +21,10 @@
 			"apiVersion": "v1",
 			"kind": "Secret",
 			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-password": "{.data['application-password']}",
+					"template.openshift.io/expose-username": "{.data['application-user']}"
+				},
 				"name": "${NAME}"
 			},
 			"stringData": {
@@ -59,6 +62,9 @@
 			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
+				"annotations": {
+					"template.openshift.io/expose-uri": "http://{.spec.host}{.spec.path}"
+				},
 				"name": "${NAME}"
 			},
 			"spec": {
@@ -96,9 +102,6 @@
 						"name": "${NAME}:latest"
 					}
 				},
-				"postCommit": {
-					"script": "bundle exec rake test"
-				},
 				"source": {
 					"contextDir": "${CONTEXT_DIR}",
 					"git": {
@@ -117,7 +120,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:${RUBY_VERSION}",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -140,11 +143,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"},{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.initContainers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -152,20 +156,11 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
-					"recreateParams": {
-						"pre": {
-							"execNewPod": {
-								"command": [
-									"./migrate-database.sh"
-								],
-								"containerName": "${NAME}"
-							},
-							"failurePolicy": "Abort"
-						}
-					},
 					"type": "Recreate"
 				},
 				"template": {
@@ -278,27 +273,89 @@
 									}
 								}
 							}
+						],
+						"initContainers": [
+							{
+								"command": [
+									"./migrate-database.sh"
+								],
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "SECRET_KEY_BASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "keybase",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									},
+									{
+										"name": "APPLICATION_DOMAIN",
+										"value": "${APPLICATION_DOMAIN}"
+									},
+									{
+										"name": "APPLICATION_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "APPLICATION_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "RAILS_ENV",
+										"value": "${RAILS_ENV}"
+									}
+								],
+								"image": " ",
+								"name": "ruby-init-container"
+							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -341,11 +398,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\", \"namespace\": \"openshift\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -353,7 +411,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -448,26 +508,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],
@@ -484,6 +525,20 @@
 			"displayName": "Namespace",
 			"description": "The OpenShift Namespace where the ImageStream resides.",
 			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "RUBY_VERSION",
+			"displayName": "Ruby Version",
+			"description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+			"value": "3.1-ubi8",
+			"required": true
+		},
+		{
+			"name": "POSTGRESQL_VERSION",
+			"displayName": "Postgresql Version",
+			"description": "Version of Postgresql image to be used (12-el8 by default).",
+			"value": "12-el8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-x86_64/rails/templates/rails-postgresql-example.json
+++ b/assets/operator/ocp-x86_64/rails/templates/rails-postgresql-example.json
@@ -96,9 +96,6 @@
 						"name": "${NAME}:latest"
 					}
 				},
-				"postCommit": {
-					"script": "bundle exec rake test"
-				},
 				"source": {
 					"contextDir": "${CONTEXT_DIR}",
 					"git": {
@@ -117,7 +114,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:${RUBY_VERSION}",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -140,11 +137,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the application server",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"},{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.initContainers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${NAME}"
@@ -152,7 +150,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${NAME}"
+					"matchLabels": {
+						"name": "${NAME}"
+					}
 				},
 				"strategy": {
 					"recreateParams": {
@@ -278,27 +278,89 @@
 									}
 								}
 							}
+						],
+						"initContainers": [
+							{
+								"command": [
+									"./migrate-database.sh"
+								],
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "SECRET_KEY_BASE",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "keybase",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									},
+									{
+										"name": "APPLICATION_DOMAIN",
+										"value": "${APPLICATION_DOMAIN}"
+									},
+									{
+										"name": "APPLICATION_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "APPLICATION_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "application-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "RAILS_ENV",
+										"value": "${RAILS_ENV}"
+									}
+								],
+								"image": " ",
+								"name": "ruby-init-container"
+							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${NAME}"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "${NAME}:latest"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		},
 		{
@@ -324,11 +386,12 @@
 			}
 		},
 		{
-			"apiVersion": "apps.openshift.io/v1",
-			"kind": "DeploymentConfig",
+			"apiVersion": "apps/v1",
+			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:12-el8\", \"namespace\": \"openshift\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -336,7 +399,9 @@
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${DATABASE_SERVICE_NAME}"
+					"matchLabels": {
+						"name": "${DATABASE_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -429,26 +494,7 @@
 							}
 						]
 					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"postgresql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "postgresql:12-el8",
-								"namespace": "${NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
+				}
 			}
 		}
 	],
@@ -465,6 +511,13 @@
 			"displayName": "Namespace",
 			"description": "The OpenShift Namespace where the ImageStream resides.",
 			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "RUBY_VERSION",
+			"displayName": "Ruby Version",
+			"description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+			"value": "3.1-ubi8",
 			"required": true
 		},
 		{

--- a/assets/operator/ocp-x86_64/ruby/imagestreams/ruby-rhel.json
+++ b/assets/operator/ocp-x86_64/ruby/imagestreams/ruby-rhel.json
@@ -14,63 +14,19 @@
 		},
 		"tags": [
 			{
-				"name": "latest",
+				"name": "2.5-ubi8",
 				"annotations": {
-					"description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.1/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+					"description": "Build and run Ruby 2.5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby (Latest)",
+					"openshift.io/display-name": "Ruby 2.5 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby",
-					"tags": "builder,ruby"
-				},
-				"from": {
-					"kind": "ImageStreamTag",
-					"name": "3.1-ubi8"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.1-ubi9",
-				"annotations": {
-					"description": "Build and run Ruby 3.1 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
-					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.1 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.1,ruby",
 					"tags": "builder,ruby",
-					"version": "3.1"
+					"version": "2.5"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/ruby-31:latest"
-				},
-				"generation": null,
-				"importPolicy": {},
-				"referencePolicy": {
-					"type": "Local"
-				}
-			},
-			{
-				"name": "3.0-ubi9",
-				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
-					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 9)",
-					"openshift.io/provider-display-name": "Red Hat, Inc.",
-					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
-					"tags": "builder,ruby",
-					"version": "3.0"
-				},
-				"from": {
-					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi9/ruby-30:latest"
+					"name": "registry.redhat.io/ubi8/ruby-25:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -86,7 +42,6 @@
 					"openshift.io/display-name": "Ruby 3.1 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.1,ruby",
 					"tags": "builder,ruby",
 					"version": "3.1"
 				},
@@ -101,20 +56,19 @@
 				}
 			},
 			{
-				"name": "3.0-ubi8",
+				"name": "3.3-ubi8",
 				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+					"description": "Build and run Ruby 3.3 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 8)",
+					"openshift.io/display-name": "Ruby 3.3 (UBI 8)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
 					"tags": "builder,ruby",
-					"version": "3.0"
+					"version": "3.3"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/ruby-30:latest"
+					"name": "registry.redhat.io/ubi8/ruby-33:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -123,20 +77,19 @@
 				}
 			},
 			{
-				"name": "3.0-ubi7",
+				"name": "3.0-ubi9",
 				"annotations": {
-					"description": "Build and run Ruby 3.0 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+					"description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 3.0 (UBI 7)",
+					"openshift.io/display-name": "Ruby 3.0 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:3.0,ruby",
 					"tags": "builder,ruby",
 					"version": "3.0"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi7/ruby-30:latest"
+					"name": "registry.redhat.io/ubi9/ruby-30:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -145,20 +98,61 @@
 				}
 			},
 			{
-				"name": "2.5-ubi8",
+				"name": "3.1-ubi9",
 				"annotations": {
-					"description": "Build and run Ruby 2.5 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
+					"description": "Build and run Ruby 3.1 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
 					"iconClass": "icon-ruby",
-					"openshift.io/display-name": "Ruby 2.5 (UBI 8)",
+					"openshift.io/display-name": "Ruby 3.1 (UBI 9)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
 					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-					"supports": "ruby:2.5,ruby",
 					"tags": "builder,ruby",
-					"version": "2.5"
+					"version": "3.1"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ubi8/ruby-25:latest"
+					"name": "registry.redhat.io/ubi9/ruby-31:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "3.3-ubi9",
+				"annotations": {
+					"description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 3.3 (UBI 9)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"tags": "builder,ruby",
+					"version": "3.3"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/ubi9/ruby-33:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+					"iconClass": "icon-ruby",
+					"openshift.io/display-name": "Ruby 3.3 (Latest)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+					"tags": "builder,ruby",
+					"version": "3.3"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "3.3-ubi9"
 				},
 				"generation": null,
 				"importPolicy": {},


### PR DESCRIPTION
This brings the 4.17 branch up-to-date with master prior to 4.17 release.