### PR TITLE
OCPBUGS-30313: Removing reference of registry.access.redhat.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REPO=quay.io/aroyo/samples-operator
+REPO=openshift
 GO_REQUIRED_MIN_VERSION = 1.13
 
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
@@ -18,7 +18,7 @@ build:
 build-image:
 	# save some time setting up the docker build context by deleting this first.
 	rm -f cluster-samples-operator        
-	podman build -t $(REPO)/origin-cluster-samples-operator:latest .
+	docker build -t docker.io/$(REPO)/origin-cluster-samples-operator:latest .
 
 test: test-unit test-e2e
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REPO=openshift
+REPO=quay.io/aroyo/samples-operator
 GO_REQUIRED_MIN_VERSION = 1.13
 
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
@@ -18,7 +18,7 @@ build:
 build-image:
 	# save some time setting up the docker build context by deleting this first.
 	rm -f cluster-samples-operator        
-	docker build -t docker.io/$(REPO)/origin-cluster-samples-operator:latest .
+	podman build -t $(REPO)/origin-cluster-samples-operator:latest .
 
 test: test-unit test-e2e
 

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -484,7 +484,6 @@ func (h *Handler) tbrInaccessible() bool {
 		return true
 	}
 	if h.imageConfigBlocksImageStreamCreation("registry.redhat.io") ||
-		h.imageConfigBlocksImageStreamCreation("registry.access.redhat.com") ||
 		h.imageConfigBlocksImageStreamCreation("quay.io") {
 		return true
 	}

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -355,15 +355,9 @@ func redHatRegistriesDomainFound(allowedDomains map[string]bool) bool {
 	return (allowedDomains["registry.redhat.io"] &&
 		allowedDomains["quay.io"]) ||
 		(allowedDomains["registry.redhat.io"] &&
-			allowedDomains["access.redhat.com"] &&
-			allowedDomains["quay.io"]) ||
-		(allowedDomains["registry.redhat.io"] &&
 			allowedDomains["redhat.com"] &&
 			allowedDomains["quay.io"]) ||
 		(allowedDomains["redhat.io"] &&
-			allowedDomains["quay.io"]) ||
-		(allowedDomains["redhat.io"] &&
-			allowedDomains["access.redhat.com"] &&
 			allowedDomains["quay.io"]) ||
 		(allowedDomains["redhat.io"] &&
 			allowedDomains["redhat.com"] &&

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -355,9 +355,15 @@ func redHatRegistriesDomainFound(allowedDomains map[string]bool) bool {
 	return (allowedDomains["registry.redhat.io"] &&
 		allowedDomains["quay.io"]) ||
 		(allowedDomains["registry.redhat.io"] &&
+			allowedDomains["access.redhat.com"] &&
+			allowedDomains["quay.io"]) ||
+		(allowedDomains["registry.redhat.io"] &&
 			allowedDomains["redhat.com"] &&
 			allowedDomains["quay.io"]) ||
 		(allowedDomains["redhat.io"] &&
+			allowedDomains["quay.io"]) ||
+		(allowedDomains["redhat.io"] &&
+			allowedDomains["access.redhat.com"] &&
 			allowedDomains["quay.io"]) ||
 		(allowedDomains["redhat.io"] &&
 			allowedDomains["redhat.com"] &&

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -342,21 +342,17 @@ func (h *Handler) updateCfgArch(cfg *v1.Config) *v1.Config {
 func redHatRegistriesFound(allowedRegistries map[string]bool) bool {
 	// Empty Sample Registry will be allowed as long as allowed registries contanis:
 	// - registry.redhat.io
-	// - registry.access.redhat.com
 	// - quay.io
 	return allowedRegistries["registry.redhat.io"] &&
-		allowedRegistries["registry.access.redhat.com"] &&
 		allowedRegistries["quay.io"]
 }
 
 func redHatRegistriesDomainFound(allowedDomains map[string]bool) bool {
 	// Empty Sample Registry will be allowed as long as allowed domains contanis:
 	// - registry.redhat.io
-	// - registry.access.redhat.com
 	// - quay.io
 	// or a domain combination that covers above registries
 	return (allowedDomains["registry.redhat.io"] &&
-		allowedDomains["registry.access.redhat.com"] &&
 		allowedDomains["quay.io"]) ||
 		(allowedDomains["registry.redhat.io"] &&
 			allowedDomains["access.redhat.com"] &&
@@ -365,7 +361,6 @@ func redHatRegistriesDomainFound(allowedDomains map[string]bool) bool {
 			allowedDomains["redhat.com"] &&
 			allowedDomains["quay.io"]) ||
 		(allowedDomains["redhat.io"] &&
-			allowedDomains["registry.access.redhat.com"] &&
 			allowedDomains["quay.io"]) ||
 		(allowedDomains["redhat.io"] &&
 			allowedDomains["access.redhat.com"] &&

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -316,7 +316,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 					},
 				},
 			},
-			ExpectedResult: true,
+			ExpectedResult: false,
 		},
 		{
 			Name:         "Test AllowRegistriesForImport whitelisted but empty registry name (2)",
@@ -404,7 +404,7 @@ func buildBlockTestScenarios() []BlockTestScenario {
 					},
 				},
 			},
-			ExpectedResult: true,
+			ExpectedResult: false,
 		},
 		{
 			Name:         "Test AllowRegistriesForImport not whitelisted",


### PR DESCRIPTION
Testing the removal of registry.access.redhat.com on redHatRegistriesFound and redHatRegistriesDomainFound functions

The objective of this is to see if the tests actually passes with the removal of this registry as the imagestreams should be able to be created even if registry.access.redhat.com is not on the registrySources.allowedRegistries of the image.config/cluster CR