### PR TITLE
OCPBUGS-48182: add shannon and aroyoredhat as owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,8 @@ reviewers:
 - fbm3307
 - mfrancisc
 - metlos
+- shannon
+- aroyoredhat
 approvers:
 - gabemontero
 - adambkaplan
@@ -12,4 +14,6 @@ approvers:
 - fbm3307
 - mfrancisc
 - metlos
+- shannon
+- aroyoredhat
 component: Samples Operator


### PR DESCRIPTION
As OCP sustaining takes on responsibility for the Cluster Samples Operator component, shannon and aroyoredhat need to be added as owners.
