### PR TITLE
OCPBUGS-45049: Adding mutex to func createSamples on handler.go

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -1151,6 +1151,8 @@ func (h *Handler) abortForDelete(cfg *v1.Config) bool {
 func (h *Handler) createSamples(cfg *v1.Config, updateIfPresent, registryChanged bool, unskippedStreams, unskippedTemplates map[string]bool) (bool, error) {
 	// first, got through the list and prime our upsert cache
 	// prior to any actual upserts
+	h.mapsMutex.Lock()
+	defer h.mapsMutex.Unlock()
 	imagestreams := []*imagev1.ImageStream{}
 	for _, fileName := range h.imagestreamFile {
 		if h.abortForDelete(cfg) {


### PR DESCRIPTION
It seems that the error appears when iterating with some maps that are being readed on the createSamples func.

Testing if putting a lock on the createSamples func avoids this type of situantion without affecting the performance of the component

~~~
fatal error: concurrent map iteration and map write

goroutine 228 [running]:
[github.com/openshift/cluster-samples-operator/pkg/stub.(*Handler).createSamples](https://github.com/openshift/cluster-samples-operator/pkg/stub.(*Handler).createSamples)(0xc0005b26e0, 0xc000bf0200, 0x0, 0x0, 0xc000217740, 0xc00104ffb0)
        /go/src/[github.com/openshift/cluster-samples-operator/pkg/stub/handler.go:1167](https://github.com/openshift/cluster-samples-operator/pkg/stub/handler.go:1167) +0xc5
[github.com/openshift/cluster-samples-operator/pkg/stub.(*Handler).Handle](https://github.com/openshift/cluster-samples-operator/pkg/stub.(*Handler).Handle)(0xc0005b26e0, {{0x253b590?, 0xc000a22600?}, 0x0?})
        /go/src/[github.com/openshift/cluster-samples-operator/pkg/stub/handler.go:952](https://github.com/openshift/cluster-samples-operator/pkg/stub/handler.go:952) +0x1c34
[github.com/openshift/cluster-samples-operator/pkg/operator.(*Controller).handleWork](https://github.com/openshift/cluster-samples-operator/pkg/operator.(*Controller).handleWork)(0xc0005c6140, {0x2533b80?, 0x39250c8}, {0x1db2ea0?, 0xc000b3f460})
~~~

~~~
2024-11-05T22:47:35.818480092Z time="2024-11-05T22:47:35Z" level=info msg="clearImageStreamTagError: stream fuse7-karaf-openshift-jdk11 already deleted so no worries on clearing tags"
2024-11-05T22:47:35.818480092Z time="2024-11-05T22:47:35Z" level=info msg="There are no more errors or image imports in flight for imagestream fuse7-karaf-openshift-jdk11"
2024-11-05T22:47:35.827118301Z fatal error: concurrent map iteration and map write
2024-11-05T22:47:35.829238519Z 
2024-11-05T22:47:35.829238519Z goroutine 251 [running]:
2024-11-05T22:47:35.829238519Z github.com/openshift/cluster-samples-operator/pkg/stub.(*Handler).createSamples(0xc000932f20, 0xc000d82c00, 0x0, 0x0, 0xc000342ed0, 0xc000342ea0)
2024-11-05T22:47:35.829238519Z 	/go/src/github.com/openshift/cluster-samples-operator/pkg/stub/handler.go:1221 +0x516
2024-11-05T22:47:35.829257997Z github.com/openshift/cluster-samples-operator/pkg/stub.(*Handler).Handle(0xc000932f20, {{0x253b590?, 0xc001141000?}, 0xb0?})
2024-11-05T22:47:35.829257997Z 	/go/src/github.com/openshift/cluster-samples-operator/pkg/stub/handler.go:952 +0x1c34
~~~

