### PR TITLE
OCPBUGS-52848: Revert "OCPBUGS-45049: Adding mutex to func createSamples on handler.go"

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -1151,8 +1151,6 @@ func (h *Handler) abortForDelete(cfg *v1.Config) bool {
 func (h *Handler) createSamples(cfg *v1.Config, updateIfPresent, registryChanged bool, unskippedStreams, unskippedTemplates map[string]bool) (bool, error) {
 	// first, got through the list and prime our upsert cache
 	// prior to any actual upserts
-	h.mapsMutex.Lock()
-	defer h.mapsMutex.Unlock()
 	imagestreams := []*imagev1.ImageStream{}
 	for _, fileName := range h.imagestreamFile {
 		if h.abortForDelete(cfg) {


### PR DESCRIPTION
Reverts https://github.com/openshift/cluster-samples-operator/pull/601

Samples operator is the only one that is failing the nightly now and we are running out of ideas as to what could be the cause for this. We are reverting both https://github.com/openshift/cluster-samples-operator/pull/602 and https://github.com/openshift/cluster-samples-operator/pull/601 and see if that will make a difference with the official payload run. If proven unrelated, please unrevert this revert and have the change reintroduced to main.