### PR TITLE
NO-JIRA: cleanup hello-openshift yaml 

### DIFF
--- a/manifests/08-openshift-imagestreams.yaml
+++ b/manifests/08-openshift-imagestreams.yaml
@@ -145,29 +145,6 @@ spec:
         kind: DockerImage
         name: quay.io/openshift/origin-oauth-proxy-samples:v4.4
 ---
-# we have to remove imagestreams here not via deletion, but per a CVO annotation
-# in order to properly conform with its conventions
-kind: ImageStream
-apiVersion: image.openshift.io/v1
-metadata:
-  namespace: openshift
-  name: hello-openshift
-  annotations:
-    release.openshift.io/delete: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-spec:
-  lookupPolicy:
-    local: true
-  tags:
-    - name: latest
-      importPolicy:
-        scheduled: true
-        importMode: PreserveOriginal
-      from:
-        kind: DockerImage
-        name: quay.io/openshift/origin-hello-openshift:latest
----
 kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:


### PR DESCRIPTION
This hello-openshift ImageStream  is removed in ocp 4.8 within https://github.com/openshift/cluster-samples-operator/pull/380

And now the OCP 4.18 has no longer need this YAML anymore, remove the redundant YAML

<img width="329" alt="image" src="https://github.com/user-attachments/assets/537976b9-9d2e-4602-a92f-8d9d59c10d31" />
