### PR TITLE
OCPBUGS-60179: Bump Kubernetes Version to v0.33.3 - update Dockerfile.okd

### DIFF
--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-samples-operator
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.18
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.20
 COPY --from=builder /go/src/github.com/openshift/cluster-samples-operator/cluster-samples-operator /usr/bin/
 RUN ln -f /usr/bin/cluster-samples-operator /usr/bin/cluster-samples-operator-watch
 COPY manifests/image-references manifests/0* /manifests/


### PR DESCRIPTION
OCPBUGS-60179: Bump Kubernetes Version to v0.33.3 - update Dockerfile.okd