### PR TITLE
CNF-23044: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
@@ -1267,7 +1266,7 @@ func getImageClient(restconfig *restclient.Config) (*imagev1client.ImageV1Client
 }
 
 func GetNamespace() string {
-	b, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/" + corev1.ServiceAccountNamespaceKey)
+	b, _ := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/" + corev1.ServiceAccountNamespaceKey)
 	return string(b)
 }
 

--- a/pkg/stub/interfaces.go
+++ b/pkg/stub/interfaces.go
@@ -3,7 +3,6 @@ package stub
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -158,7 +157,7 @@ type DefaultImageStreamFromFileGetter struct {
 }
 
 func (g *DefaultImageStreamFromFileGetter) Get(fullFilePath string) (is *imagev1.ImageStream, err error) {
-	isjsonfile, err := ioutil.ReadFile(fullFilePath)
+	isjsonfile, err := os.ReadFile(fullFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +182,7 @@ type DefaultTemplateFromFileGetter struct {
 }
 
 func (g *DefaultTemplateFromFileGetter) Get(fullFilePath string) (t *templatev1.Template, err error) {
-	tjsonfile, err := ioutil.ReadFile(fullFilePath)
+	tjsonfile, err := os.ReadFile(fullFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -207,8 +206,19 @@ type DefaultResourceFileLister struct {
 }
 
 func (g *DefaultResourceFileLister) List(dir string) (files []os.FileInfo, err error) {
-	files, err = ioutil.ReadDir(dir)
-	return files, err
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	files = make([]os.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, info)
+	}
+	return files, nil
 
 }
 

--- a/test/e2e/cluster_samples_operator_test.go
+++ b/test/e2e/cluster_samples_operator_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -108,7 +108,7 @@ func dumpPod(t *testing.T) {
 				if err != nil {
 					t.Fatalf("error getting pod logs for container %s: %s", container.Name, err.Error())
 				}
-				b, err := ioutil.ReadAll(readCloser)
+				b, err := io.ReadAll(readCloser)
 				if err != nil {
 					t.Fatalf("error reading pod stream %s", err.Error())
 				}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Migration from `ioutil` to `os`/`io` functions:**

* Replaced `ioutil.TempFile` with `os.CreateTemp` in `generateTempCertificates()` in `pkg/metrics/server_test.go`. [[1]](diffhunk://#diff-edaa19bd1153b6344fc81139e2e1c4c8cef837c79e4e5ef57b61fdff2f0e04daL79-R78) [[2]](diffhunk://#diff-edaa19bd1153b6344fc81139e2e1c4c8cef837c79e4e5ef57b61fdff2f0e04daL89-R88)
* Replaced `ioutil.ReadFile` with `os.ReadFile` in `GetNamespace()` in `pkg/stub/handler.go`, and in file reading methods in `pkg/stub/interfaces.go`. [[1]](diffhunk://#diff-8cbb3be964d3e67dbcd9961debdf80e528c1b37b311769fba698f3bd7ea49949L1270-R1269) [[2]](diffhunk://#diff-c0c79f6df140d436132fcc6e1ecb7c3dba747710b6c957ce1391e140b36a3987L161-R160) [[3]](diffhunk://#diff-c0c79f6df140d436132fcc6e1ecb7c3dba747710b6c957ce1391e140b36a3987L186-R185)
* Replaced `ioutil.ReadDir` with `os.ReadDir` and updated logic to convert `DirEntry` to `FileInfo` in `DefaultResourceFileLister.List()` in `pkg/stub/interfaces.go`.
* Replaced `ioutil.ReadAll` with `io.ReadAll` in `dumpPod()` in `test/e2e/cluster_samples_operator_test.go`.

**Imports cleanup:**

* Removed unused `ioutil` imports and added `io` where needed in affected files. [[1]](diffhunk://#diff-edaa19bd1153b6344fc81139e2e1c4c8cef837c79e4e5ef57b61fdff2f0e04daL11) [[2]](diffhunk://#diff-8cbb3be964d3e67dbcd9961debdf80e528c1b37b311769fba698f3bd7ea49949L8) [[3]](diffhunk://#diff-c0c79f6df140d436132fcc6e1ecb7c3dba747710b6c957ce1391e140b36a3987L6) [[4]](diffhunk://#diff-2925f55eb6e123965e6b19c1d933bb9ff1c4329305ecba603ee2e59c1f078f2aL7-R7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized internal code to use current Go standard library APIs instead of deprecated functions throughout the codebase. This update improves code maintainability, ensures long-term compatibility with future Go versions, and aligns with best practices for contemporary Go development. All changes are internal implementation details with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->