### PR TITLE
OKD-379: Fix missing namespace in database template image triggers

### DIFF
--- a/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-example.json
+++ b/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-example.json
@@ -298,7 +298,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"mysql:${MYSQL_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-persistent.json
+++ b/assets/operator/okd-x86_64/cakephp/templates/cakephp-mysql-persistent.json
@@ -369,7 +369,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"mysql:${MYSQL_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-example.json
+++ b/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-example.json
@@ -271,6 +271,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
+					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -476,6 +477,13 @@
 			"name": "CPAN_MIRROR",
 			"displayName": "Custom CPAN Mirror URL",
 			"description": "The custom CPAN mirror URL"
+		},
+		{
+			"name": "MYSQL_VERSION",
+			"displayName": "Version of MySQL Image",
+			"description": "Version of MySQL image to be used (8.0-el8, 8.0-el9, or latest).",
+			"value": "8.0-el8",
+			"required": true
 		},
 		{
 			"name": "MYSQL_DEFAULT_AUTHENTICATION_PLUGIN",

--- a/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-persistent.json
+++ b/assets/operator/okd-x86_64/dancer/templates/dancer-mysql-persistent.json
@@ -288,7 +288,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "Defines how to deploy the database",
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"mysql:${MYSQL_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/mariadb/templates/mariadb-ephemeral.json
+++ b/assets/operator/okd-x86_64/mariadb/templates/mariadb-ephemeral.json
@@ -62,7 +62,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"mariadb:${MARIADB_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/mariadb/templates/mariadb-persistent.json
+++ b/assets/operator/okd-x86_64/mariadb/templates/mariadb-persistent.json
@@ -79,7 +79,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"mariadb:${MARIADB_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/mysql/templates/mysql-ephemeral.json
+++ b/assets/operator/okd-x86_64/mysql/templates/mysql-ephemeral.json
@@ -70,7 +70,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"mysql:${MYSQL_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/mysql/templates/mysql-persistent.json
+++ b/assets/operator/okd-x86_64/mysql/templates/mysql-persistent.json
@@ -41,7 +41,6 @@
 			"kind": "Service",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.openshift.io/expose-uri": "mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\"mysql\")].port}"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"
@@ -80,7 +79,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mysql:${MYSQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"mysql:${MYSQL_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/postgresql/templates/postgresql-ephemeral.json
+++ b/assets/operator/okd-x86_64/postgresql/templates/postgresql-ephemeral.json
@@ -68,7 +68,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"postgresql:${POSTGRESQL_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/postgresql/templates/postgresql-persistent.json
+++ b/assets/operator/okd-x86_64/postgresql/templates/postgresql-persistent.json
@@ -85,7 +85,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:${POSTGRESQL_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"postgresql:${POSTGRESQL_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/redis/templates/redis-ephemeral.json
+++ b/assets/operator/okd-x86_64/redis/templates/redis-ephemeral.json
@@ -64,7 +64,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"redis:${REDIS_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"redis:${REDIS_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"

--- a/assets/operator/okd-x86_64/redis/templates/redis-persistent.json
+++ b/assets/operator/okd-x86_64/redis/templates/redis-persistent.json
@@ -81,7 +81,7 @@
 			"kind": "Deployment",
 			"metadata": {
 				"annotations": {
-					"image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"redis:${REDIS_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
+					"image.openshift.io/triggers": "[{\"from\": {\"kind\": \"ImageStreamTag\", \"name\": \"redis:${REDIS_VERSION}\", \"namespace\": \"${NAMESPACE}\"}, \"fieldPath\": \"spec.template.spec.containers[0].image\"}]",
 					"template.alpha.openshift.io/wait-for-ready": "true"
 				},
 				"name": "${DATABASE_SERVICE_NAME}"


### PR DESCRIPTION
## Problem

Deploying databases (PostgreSQL, MySQL, MariaDB, Redis) from the Software Catalog on OKD 4.22 fails with:

```
spec.containers[0].image: Invalid value: " ": must not have leading or trailing whitespace
```

Reported in https://github.com/okd-project/okd/issues/2337

### Root Cause

When database templates were migrated from `DeploymentConfig` to `Deployment` ([openshift/library@f865a9e2](https://github.com/openshift/library/commit/f865a9e2), Dec 2023), the `image.openshift.io/triggers` annotation on database Deployments dropped the `namespace` field from the `ImageStreamTag` reference.

The old `DeploymentConfig` trigger had:
```json
{"from": {"kind": "ImageStreamTag", "name": "postgresql:${POSTGRESQL_VERSION}", "namespace": "${NAMESPACE}"}}
```

The new `Deployment` annotation was missing `namespace`:
```json
{"from": {"kind": "ImageStreamTag", "name": "postgresql:${POSTGRESQL_VERSION}"}}
```

Without an explicit namespace, the [image trigger controller](https://github.com/openshift/library-go/blob/master/pkg/image/trigger/annotations/annotations.go#L138-L142) defaults to the Deployment's own namespace (the user's project) instead of `openshift`. Since database ImageStreams live in the `openshift` namespace, the lookup fails and the container image is never resolved — it stays as `" "` (a single space placeholder). Kubernetes then rejects the pod with the whitespace validation error.

## Fix

Add `"namespace": "${NAMESPACE}"` to the `from` object in the `image.openshift.io/triggers` annotation on all affected database Deployments. The `NAMESPACE` parameter already exists in every template with a default value of `"openshift"`, so no new parameters are needed.

### Templates fixed (11 files — namespace added to trigger):

| Template | ImageStreamTag |
|---|---|
| `postgresql-persistent` | `postgresql:${POSTGRESQL_VERSION}` |
| `postgresql-ephemeral` | `postgresql:${POSTGRESQL_VERSION}` |
| `mysql-persistent` | `mysql:${MYSQL_VERSION}` |
| `mysql-ephemeral` | `mysql:${MYSQL_VERSION}` |
| `mariadb-persistent` | `mariadb:${MARIADB_VERSION}` |
| `mariadb-ephemeral` | `mariadb:${MARIADB_VERSION}` |
| `redis-persistent` | `redis:${REDIS_VERSION}` |
| `redis-ephemeral` | `redis:${REDIS_VERSION}` |
| `cakephp-mysql-example` | `mysql:${MYSQL_VERSION}` |
| `cakephp-mysql-persistent` | `mysql:${MYSQL_VERSION}` |
| `dancer-mysql-persistent` | `mysql:${MYSQL_VERSION}` |

### Additional fixes:

- **`dancer-mysql-example`**: The database Deployment had `"image": " "` but was entirely missing the `image.openshift.io/triggers` annotation — image resolution could never fire. Added the trigger annotation with namespace. Also added the missing `MYSQL_VERSION` parameter (default `"8.0-el8"`).
- **`mysql-persistent`**: Removed a stray `image.openshift.io/triggers` annotation from the Service object. It was a copy-paste error that referenced `${MARIADB_VERSION}` — Services don't have containers, so this annotation had no effect but was incorrect.

### OCP impact: None

All changes are under `assets/operator/okd-x86_64/` only. OCP Dockerfiles (`Dockerfile`, `Dockerfile.rhel7`) copy from `ocp-x86_64` / `ocp-s390x` / `ocp-ppc64le` / `ocp-aarch64`. Only `Dockerfile.okd` copies from `okd-x86_64`. The two directory trees are completely separate.