### PR TITLE
OCPSTRAT-3578: Add NetworkPolicy manifests for openshift-cluster-samples-operator namespace

### DIFF
--- a/manifests/011-network-policy.yaml
+++ b/manifests/011-network-policy.yaml
@@ -1,0 +1,88 @@
+# NetworkPolicy for the openshift-cluster-samples-operator namespace.
+#
+# This operator is a core component that owns the entire namespace, so we use
+# a namespace-wide default deny and then add back only the traffic that is
+# required:
+#   - Egress to cluster DNS (openshift-dns, port 5353)
+#   - Egress to the Kubernetes API server (must be allow-all because the API
+#     server runs on the host network and its IP/port cannot be targeted by NP)
+#   - Ingress to the metrics endpoint (port 60000/TCP) from any pod (Prometheus)
+#
+# Health-check probes from the kubelet are not affected by NetworkPolicy.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-cluster-samples-operator
+  annotations:
+    capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-to-dns
+  namespace: openshift-cluster-samples-operator
+  annotations:
+    capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  podSelector: {}
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: TCP
+      port: 5353
+    - protocol: UDP
+      port: 5353
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-api-server
+  namespace: openshift-cluster-samples-operator
+  annotations:
+    capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  podSelector:
+    matchLabels:
+      name: cluster-samples-operator
+  egress:
+  - {}
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-metrics
+  namespace: openshift-cluster-samples-operator
+  annotations:
+    capability.openshift.io/name: openshift-samples
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  podSelector:
+    matchLabels:
+      name: cluster-samples-operator
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 60000
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
## Summary

Implements tailored NetworkPolicy resources for the `openshift-cluster-samples-operator` namespace per [HPSTRAT-104](https://redhat.atlassian.net/browse/HPSTRAT-104) / [OCPSTRAT-3578](https://redhat.atlassian.net/browse/OCPSTRAT-3578).

This satisfies:
- CIS Kube benchmark 5.3.2 ("Ensure that all Namespaces have Network Policies defined")
- Red Hat ProdSec guidance on control plane network hardening for OCP 5.0

### Policies added

| Policy | Purpose |
|--------|---------|
| `default-deny` | Namespace-wide deny-all for both ingress and egress (`podSelector: {}`) |
| `allow-to-dns` | All pods can reach `openshift-dns` on port 5353 (TCP + UDP) |
| `allow-egress-to-api-server` | Operator pods get unrestricted egress (API server is host-networked, IP/port cannot be targeted by NetworkPolicy) |
| `allow-ingress-to-metrics` | Operator pods accept inbound TCP on port 60000 (Prometheus scraping) |

### Notes

- Health-check probes from the kubelet are **not** affected by NetworkPolicy
- The operator requires unrestricted egress because it communicates with the Kubernetes API server (host-networked) and external container registries for ImageStream imports
- All policies carry the standard `capability.openshift.io/name: openshift-samples` and release inclusion annotations

## Test plan

- [ ] Deploy to a cluster with OVN-Kubernetes and verify the operator starts and reconciles successfully
- [ ] Confirm ImageStream imports continue to work
- [ ] Confirm Prometheus can scrape metrics on port 60000
- [ ] Verify `oc get networkpolicy -n openshift-cluster-samples-operator` shows all four policies
- [ ] Run CIS benchmark scan and confirm 5.3.2 passes for this namespace